### PR TITLE
[codex] Clarify single-app dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,59 @@
 # Accxui
 
-# Prerequisite
-Node - v22.12.0 or higher
+## Prerequisite
 
-# Build Notes
+- Node `v22.12.0` or higher
+- `pnpm`
 
-1. Open a Terminal window
-2. Clone app using the command: `git clone https://github.com/hotwax/accxui.git <repository-name>`
-3. Go to the <repository-name> directory using command: `cd <repository-name>`
-4. Go to apps directory and clone any HotWax PWA app, like https://github.com/hotwax/fulfillment/
-5. Create a `.env` file by taking reference from the `.env.example` in the cloned app
-6. Go to root and run following command to download dependencies
-    `pnpm i`
-7. To run the app use the command from root: `pnpm --filter <app-name> dev`
-8. To build the app, use the command from root: `pnpm --filter <app-name> build`
+## Workspace Setup
+
+`accxui` is a pnpm workspace. Apps are developed from the workspace root, not by running `npm serve` or `pnpm dev` inside an app folder directly.
+
+1. Open a terminal window.
+2. Clone the workspace:
+   `git clone https://github.com/hotwax/accxui.git`
+3. Go to the workspace root:
+   `cd accxui`
+4. Add the app you want to work on under `apps/`.
+   Example:
+   `git clone https://github.com/hotwax/fulfillment.git apps/fulfillment`
+5. Create a `.env` file in that app by taking reference from its `.env.example`.
+6. Install dependencies once from the `accxui` root:
+   `pnpm install`
+
+## Start A Single App
+
+Run app commands from the `accxui` root and target the app with `--filter`.
+
+Examples:
+
+```bash
+pnpm --filter fulfillment dev
+pnpm --filter receiving dev
+pnpm --filter bopis dev
+pnpm --filter available-to-promise dev
+pnpm --filter job-manager dev
+```
+
+This starts only the selected app in development mode.
+
+## Build A Single App
+
+```bash
+pnpm --filter <app-name> build
+```
+
+Example:
+
+```bash
+pnpm --filter fulfillment build
+```
+
+## Useful Notes
+
+- Run `pnpm install` from the `accxui` root after adding a new app to `apps/`.
+- Keep each app inside `apps/<app-name>` so the workspace can discover it.
+- If you want to start multiple apps, run separate `pnpm --filter <app-name> dev` commands.
 
 ## Report a bug or request a feature
 
@@ -27,4 +67,3 @@ You may find some useful resources for improving the UI / UX of the app <a href=
 
 # Join the community on Discord
 If you have any questions or ideas feel free to join our <a href="https://discord.gg/SwpJnpdyg3" target="_blank">Discord channel</a>.
-


### PR DESCRIPTION
## What changed
- updated the accxui README to explain the pnpm workspace setup
- documented how to add an app under `apps/`
- documented how to start and build a single app with `pnpm --filter <app-name> ...`

## Why
Developers were treating accxui like a regular per-repo app setup, but the refactored flow depends on the workspace root and filtered pnpm commands.

## Impact
This makes local setup clearer for anyone starting development on one app at a time inside the accxui workspace.

## Validation
- reviewed the README instructions against the current local workspace setup
