### PR TITLE
feat: add more context to global error handler

### DIFF
--- a/common/core/logger.ts
+++ b/common/core/logger.ts
@@ -41,7 +41,11 @@ export default {
   install(app: any, options: any) {
 
     app.config.errorHandler = (error: any, instance: any, info: any) => {
-      logger.error("Global handler:", getStack(error), instance, info);
+      const componentInfo = instance ? {
+        name: instance.$options?.name || instance?.$options?.__name,
+        uid: instance?._uid || instance?.$?.uid
+      } : null;
+      logger.error("Global handler:", getStack(error), componentInfo, info);
     }
     const level = options.level ? options.level : "error"
 

--- a/common/core/logger.ts
+++ b/common/core/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger, StringifyObjectsHook } from 'vue-logger-plugin'
+import { StringifyObjectsHook, createLogger } from "vue-logger-plugin"
 
 // TODO Implement logic to send logs to server
 // https://github.com/dev-tavern/vue-logger-plugin#sample-custom-hook---leveraging-axios-to-send-logs-to-server
@@ -20,19 +20,20 @@ import { createLogger, StringifyObjectsHook } from 'vue-logger-plugin'
 
 const logger = createLogger({
   enabled: true,
-  beforeHooks: [ StringifyObjectsHook ]
+  beforeHooks: [StringifyObjectsHook]
 });
 
 function getStack(error: any) {
   // Handling incompatibilities
-  // Non-standard: This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. 
+  // Non-standard: This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user.
   // There may also be large incompatibilities between implementations and the behavior may change in the future.
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
   try {
-    return error.stack;
-  } catch (err) {
+    return error.stack || error;
+  } catch {
     logger.warn("Error stack is not supported");
   }
+
   return error;
 }
 
@@ -40,8 +41,7 @@ export default {
   install(app: any, options: any) {
 
     app.config.errorHandler = (error: any, instance: any, info: any) => {
-      // TODO Improve code to add more information related to code failed
-      logger.error("Global handler:" + getStack(error));
+      logger.error("Global handler:", getStack(error), instance, info);
     }
     const level = options.level ? options.level : "error"
 


### PR DESCRIPTION
Improved the global Vue error handler in `common/core/logger.ts` to include the component instance and lifecycle info in the log output. This provides better visibility into where and why an error occurred. Also refined `getStack` to safely return the error stack or the error object itself, and fixed linting issues in the file.

---
*PR created automatically by Jules for task [4199331523344424010](https://jules.google.com/task/4199331523344424010) started by @dt2patel*