### PR TITLE
Fix auth cookie scope to host-only

### DIFF
--- a/common/helpers/cookieHelper.ts
+++ b/common/helpers/cookieHelper.ts
@@ -2,7 +2,7 @@ export const cookieHelper = () => {
 
     // Function to set a cookie with an optional expiration
     const set = (name: string, value: string, maxAge?: number) => {
-        let cookieString = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; path=/; SameSite=Lax; ${!import.meta.env.DEV && "domain=hotwax.io"}`;
+        let cookieString = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
         if (maxAge) {
             cookieString += `; max-age=${maxAge}`;
         } else {


### PR DESCRIPTION
### Motivation
- The cookie helper was adding `domain=hotwax.io` in `common/helpers/cookieHelper.ts`, which scoped JavaScript-accessible auth cookies to the parent domain and exposed `token`/session material to all `*.hotwax.io` subdomains, so this change restores host-only scoping to reduce the attack surface.

### Description
- Remove the `domain=hotwax.io` fragment from the cookie string in `common/helpers/cookieHelper.ts`, while preserving `path=/`, `SameSite=Lax`, and the existing `max-age` behavior.

### Testing
- Ran `pnpm -s lint`, which failed due to an existing ESLint/plugin compatibility error unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eff91722948328adbe153da006322c)