### PR TITLE
[codex] Add wrapper catalog entries for app dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@capacitor/android": "catalog:",
+    "@capacitor/clipboard": "catalog:",
     "@capacitor/core": "catalog:",
     "@capacitor/ios": "catalog:",
     "@casl/ability": "^6.7.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ catalog:
   "cronstrue": "3.13.0"
   "cron-parser": "5.4.0"
   "@capacitor/clipboard": "8.0.1"
+  "chart.js": "4.5.1"
   "@module-federation/runtime": "0.7.7"
   "@shopify/app-bridge": "3.7.11"
   "@shopify/app-bridge-utils": "3.5.1"


### PR DESCRIPTION
## Business summary

Keeps the AccxUI wrapper dependency catalog aligned with the app dependencies needed by the current workspace apps, so filtered app builds continue to resolve dependencies from the shared workspace root.

Closes #46

## Changes

- Adds `@capacitor/clipboard` to the wrapper package dependencies.
- Adds `chart.js` to the workspace catalog.

## Validation

- `pnpm --filter products build` passed after these local catalog entries were present.
- `pnpm --filter order-manager build` passed after these local catalog entries were present.
- `pnpm --filter order-routing-rules build` passed after these local catalog entries were present.
- `pnpm --filter job-manager build` passed after these local catalog entries were present.

## Notes

- This PR intentionally does not include the stale local `pnpm-lock.yaml` churn from the older local `main` checkout.
