### PR TITLE
[codex] Add configurable Moqui auth backend

### DIFF
--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import { computed, ref } from "vue";
 import emitter from "../core/emitter";
 import { accxuiConfig } from "../core/configRegistry";
+import { getMoquiBaseURL, isMoquiAuthBackend } from "../core/authBackend";
 
 interface LoginOption {
   loginAuthType?: string,
@@ -33,6 +34,7 @@ export function useAuth() {
   const updateOMS = (oms: any) => {
     cookieHelper().set("oms", oms, getDuration())
     omsRef.value = oms
+    accxuiConfig.value.oms = oms
   }
 
   const updateUserId = (userId: any) => {
@@ -81,15 +83,30 @@ export function useAuth() {
     let expiresAt = expirationTime
     try {
       if(!omsToken && username && password) {
-        const resp = await api({
-          url: "login",
-          method: "post",
-          data: {
-            "USERNAME": username,
-            "PASSWORD": password
-          },
-          baseURL: commonUtil.getOmsURL()
-        });
+        const useMoquiAuth = isMoquiAuthBackend();
+        let resp;
+        try {
+          resp = await api({
+            url: useMoquiAuth ? "admin/login" : "login",
+            method: "post",
+            data: useMoquiAuth ? {
+              "username": username,
+              "password": password
+            } : {
+              "USERNAME": username,
+              "PASSWORD": password
+            },
+            baseURL: useMoquiAuth ? getMoquiBaseURL() : commonUtil.getOmsURL()
+          });
+        } catch (err: any) {
+          if(useMoquiAuth && err?.response?.status === 401) {
+            commonUtil.showToast(translate("Sorry, your username or password is incorrect. Please try again."));
+            updateUserId("")
+            updateToken("", "")
+            return Promise.reject(err);
+          }
+          throw err;
+        }
         if(commonUtil.hasError(resp)) {
           commonUtil.showToast(translate("Sorry, your username or password is incorrect. Please try again."));
           logger.error("error", resp.data._ERROR_MESSAGE_);
@@ -101,6 +118,12 @@ export function useAuth() {
 
         omsToken = resp.data.token
         expiresAt = resp.data.expirationTime
+        if(useMoquiAuth && !cookieHelper().get("maarg")) {
+          const moquiBaseURL = getMoquiBaseURL();
+          if(moquiBaseURL) {
+            cookieHelper().set("maarg", moquiBaseURL, getDuration(expiresAt))
+          }
+        }
       }
 
       updateToken(omsToken, expiresAt)
@@ -141,19 +164,21 @@ export function useAuth() {
         }
       }
 
-      try {
-        let resp = await api({
-          url: "logout",
-          method: "GET",
-          baseURL: commonUtil.getOmsURL()
-        }) as any;
-        resp = JSON.parse(resp.data.startsWith("//") ? resp.data.replace("//", "") : resp.data);
+      if(!isMoquiAuthBackend()) {
+        try {
+          let resp = await api({
+            url: "logout",
+            method: "GET",
+            baseURL: commonUtil.getOmsURL()
+          }) as any;
+          resp = JSON.parse(resp.data.startsWith("//") ? resp.data.replace("//", "") : resp.data);
 
-        if(resp?.logoutAuthType == "SAML2SSO") {
-          redirectionUrl = resp.logoutUrl;
+          if(resp?.logoutAuthType == "SAML2SSO") {
+            redirectionUrl = resp.logoutUrl;
+          }
+        } catch (err) {
+          logger.error("Error logging out", err);
         }
-      } catch (err) {
-        logger.error("Error logging out", err);
       }
     }
 
@@ -191,14 +216,16 @@ export function useAuth() {
   const fetchLoginOptions = async () => {
     loginOption.value = {}
     try {
+      const useMoquiAuth = isMoquiAuthBackend();
       const resp = await api({
-        url: "checkLoginOptions",
+        url: useMoquiAuth ? "admin/checkLoginOptions" : "checkLoginOptions",
         method: "GET",
-        baseURL: commonUtil.getOmsURL()
+        baseURL: useMoquiAuth ? getMoquiBaseURL() : commonUtil.getOmsURL()
       });
       if(!commonUtil.hasError(resp)) {
         loginOption.value = resp.data
-        cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
+        const maargInstanceUrl = resp.data.maargInstanceUrl || resp.data.omsInstanceUrl || (useMoquiAuth ? getMoquiBaseURL() : "");
+        if(maargInstanceUrl) cookieHelper().set("maarg", maargInstanceUrl, getDuration())
       }
     } catch (error) {
       logger.error(error)

--- a/common/core/authBackend.spec.ts
+++ b/common/core/authBackend.spec.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  expandMoquiURL,
+  getAuthBackend,
+  getConfiguredMoquiBaseURL,
+  getMoquiBaseURL,
+  isMoquiAuthBackend
+} from './authBackend';
+
+describe('auth backend config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to the legacy OFBiz login flow', () => {
+    expect(getAuthBackend()).toBe('ofbiz');
+    expect(isMoquiAuthBackend()).toBe(false);
+  });
+
+  it('enables Moqui auth only when explicitly configured', () => {
+    vi.stubEnv('VITE_AUTH_BACKEND', 'moqui');
+
+    expect(getAuthBackend()).toBe('moqui');
+    expect(isMoquiAuthBackend()).toBe(true);
+  });
+
+  it('expands local Moqui hosts to the rest service base URL', () => {
+    expect(expandMoquiURL('localhost:8080')).toBe('http://localhost:8080/rest/s1/');
+    expect(expandMoquiURL('http://localhost:8080/api/')).toBe('http://localhost:8080/rest/s1/');
+    expect(expandMoquiURL('http://localhost:8080/rest/s1/admin')).toBe('http://localhost:8080/rest/s1/');
+  });
+
+  it('uses the configured Moqui base URL for local dev', () => {
+    vi.stubEnv('VITE_MOQUI_BASE_URL', 'http://localhost:8080');
+
+    expect(getConfiguredMoquiBaseURL()).toBe('http://localhost:8080/rest/s1/');
+  });
+
+  it('uses cookie-backed local Moqui URLs when no env URL is configured', () => {
+    vi.stubGlobal('document', {
+      cookie: 'maarg=localhost:8080'
+    });
+
+    expect(getMoquiBaseURL()).toBe('http://localhost:8080/rest/s1/');
+  });
+});

--- a/common/core/authBackend.ts
+++ b/common/core/authBackend.ts
@@ -1,0 +1,66 @@
+import { cookieHelper } from "../helpers/cookieHelper";
+import { useEmbeddedAppStore } from "../store/embeddedApp";
+
+export type AuthBackend = "ofbiz" | "moqui";
+
+const LOCAL_HOST_PATTERN = /^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?(?:\/.*)?$/;
+
+const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, "");
+
+const withProtocolForLocal = (value: string) => {
+  if (/^https?:\/\//i.test(value)) return value;
+  return LOCAL_HOST_PATTERN.test(value) ? `http://${value}` : value;
+};
+
+export const getAuthBackend = (): AuthBackend => {
+  const backend = (import.meta.env.VITE_AUTH_BACKEND || "").trim().toLowerCase();
+  return backend === "moqui" || backend === "local-moqui" ? "moqui" : "ofbiz";
+};
+
+export const isMoquiAuthBackend = () => getAuthBackend() === "moqui";
+
+export const expandMoquiURL = (value?: string | null) => {
+  if (!value) return "";
+
+  const normalized = withProtocolForLocal(value.trim());
+  if (!normalized) return "";
+
+  if (!/^https?:\/\//i.test(normalized)) {
+    return `https://${trimTrailingSlashes(normalized)}.hotwax.io/rest/s1/`;
+  }
+
+  const withoutTrailingSlash = trimTrailingSlashes(normalized);
+  const restIndex = withoutTrailingSlash.indexOf("/rest/s1");
+  if (restIndex >= 0) {
+    return `${withoutTrailingSlash.slice(0, restIndex)}/rest/s1/`;
+  }
+
+  const apiIndex = withoutTrailingSlash.indexOf("/api");
+  if (apiIndex >= 0) {
+    return `${withoutTrailingSlash.slice(0, apiIndex)}/rest/s1/`;
+  }
+
+  return `${withoutTrailingSlash}/rest/s1/`;
+};
+
+export const getConfiguredMoquiBaseURL = () => {
+  return expandMoquiURL(import.meta.env.VITE_MOQUI_BASE_URL);
+};
+
+export const getMoquiBaseURL = () => {
+  const configuredMoquiBaseURL = getConfiguredMoquiBaseURL();
+  if (configuredMoquiBaseURL) return configuredMoquiBaseURL;
+
+  let maarg = cookieHelper().get("maarg");
+  let oms = cookieHelper().get("oms");
+
+  try {
+    const embeddedAppStore = useEmbeddedAppStore();
+    maarg = embeddedAppStore.getMaarg || maarg;
+    oms = embeddedAppStore.getOms || oms;
+  } catch {
+    // Pinia may not be active during early app bootstrap or isolated unit tests.
+  }
+
+  return expandMoquiURL(maarg) || expandMoquiURL(oms);
+};

--- a/common/core/remoteApi.spec.ts
+++ b/common/core/remoteApi.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isAuthBypassEndpoint, prepareApiConfig } from './remoteApi';
+
+vi.mock('../composables/useAuth', () => ({
+  useAuth: () => ({
+    isAuthenticated: { value: true },
+    logout: vi.fn()
+  })
+}));
+
+describe('prepareApiConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps legacy getPermissions calls on the OFBiz API by default', () => {
+    const config = prepareApiConfig({
+      url: 'getPermissions',
+      method: 'post',
+      baseURL: 'https://example.hotwax.io/api/',
+      data: { viewIndex: 0, viewSize: 250 }
+    });
+
+    expect(config).toMatchObject({
+      url: 'getPermissions',
+      method: 'post',
+      baseURL: 'https://example.hotwax.io/api/',
+      data: { viewIndex: 0, viewSize: 250 }
+    });
+  });
+
+  it('maps getPermissions to the Moqui admin endpoint when Moqui auth is enabled', () => {
+    vi.stubEnv('VITE_AUTH_BACKEND', 'moqui');
+    vi.stubEnv('VITE_MOQUI_BASE_URL', 'http://localhost:8080');
+
+    const config = prepareApiConfig({
+      url: 'getPermissions',
+      method: 'post',
+      baseURL: 'http://localhost:8080/api/',
+      data: { viewIndex: 0, viewSize: 250 }
+    });
+
+    expect(config).toMatchObject({
+      url: 'admin/user/permissions',
+      method: 'get',
+      baseURL: 'http://localhost:8080/rest/s1/',
+      params: { viewIndex: 0, viewSize: 250 }
+    });
+    expect(config.data).toBeUndefined();
+  });
+
+  it('allows the mapped Moqui permission endpoint during login setup', () => {
+    vi.stubEnv('VITE_AUTH_BACKEND', 'moqui');
+    vi.stubEnv('VITE_MOQUI_BASE_URL', 'http://localhost:8080');
+
+    const config = prepareApiConfig({
+      url: 'getPermissions',
+      method: 'post',
+      baseURL: 'http://localhost:8080/api/',
+      data: { viewIndex: 0, viewSize: 50 }
+    });
+
+    expect(config.url).toBe('admin/user/permissions');
+    expect(isAuthBypassEndpoint(config.url)).toBe(true);
+  });
+
+  it('points legacy OMS-base calls at Moqui REST when Moqui auth is enabled', () => {
+    vi.stubEnv('VITE_AUTH_BACKEND', 'moqui');
+    vi.stubEnv('VITE_MOQUI_BASE_URL', 'http://localhost:8080');
+
+    const config = prepareApiConfig({
+      url: 'ofbiz-oms-usl/checkShippingInventory',
+      method: 'post',
+      baseURL: 'http://localhost:8080/api/',
+      data: { productId: 'SKU-1' }
+    });
+
+    expect(config).toMatchObject({
+      url: 'ofbiz-oms-usl/checkShippingInventory',
+      method: 'post',
+      baseURL: 'http://localhost:8080/rest/s1/',
+      data: { productId: 'SKU-1' }
+    });
+  });
+});

--- a/common/core/remoteApi.ts
+++ b/common/core/remoteApi.ts
@@ -4,13 +4,18 @@ import { setupCache } from 'axios-cache-adapter'
 import qs from "qs"
 import { commonUtil } from '../utils/commonUtil';
 import { useAuth } from '../composables/useAuth';
+import { getMoquiBaseURL, isMoquiAuthBackend } from './authBackend';
+
+const authBypassEndpoints = ["login", "logout", "checkLoginOptions", "admin/login", "admin/checkLoginOptions", "admin/user/profile", "getPermissions", "admin/user/permissions", "app-bridge/login"]
+
+const isAuthBypassEndpoint = (url?: string) => {
+  return !!url && authBypassEndpoints.includes(url);
+}
 
 const requestInterceptor = async (config: any) => {
   const token = commonUtil.getToken();
 
-  // The following are the endpoints needs to bypass the auth check and when this calls are made we will assume
-  // that we are always relogin with the new credentials present in cookies.
-  const noAuthEndpoints = ["login", "logout", "checkLoginOptions", "admin/user/profile", "getPermissions", "app-bridge/login"]
+  // The following endpoints bypass the auth check because they are part of login setup.
 
   // When the same app is opened in multiple tabs and logout from one tab, then another tab still uses the old
   // session, to handle this scenario we have added check to always validate authentication before api calls
@@ -18,7 +23,7 @@ const requestInterceptor = async (config: any) => {
   // the session automatically.
   // Bypass the check for endpoints that don't require authentication (like login, logout, profile),
   // as these are often called during the authentication flow itself or to refresh local state.
-  if (!useAuth().isAuthenticated.value && !noAuthEndpoints.includes(config.url)) {
+  if (!useAuth().isAuthenticated.value && !isAuthBypassEndpoint(config.url)) {
     await useAuth().logout({ isUserUnauthorised: true, invalidAppContext: true })
     useAuth().clearAuth()
     return Promise.reject(new Error("INVALID_APP_CONTEXT"));
@@ -108,7 +113,7 @@ const axiosCache = setupCache({
  * @param {boolean} [cache] - Optional: Apply caching to it
  * @return {Promise} Response from API as returned by Axios
  */
-const api = async (customConfig: any) => {
+const prepareApiConfig = (customConfig: any) => {
   // Prepare configuration
   const config: any = {
     url: customConfig.url,
@@ -126,8 +131,25 @@ const api = async (customConfig: any) => {
 
   config.baseURL = customConfig.baseURL ? customConfig.baseURL : commonUtil.getMaargURL();
 
+  if(isMoquiAuthBackend() && typeof config.baseURL === "string" && config.baseURL.includes("/api")) {
+    config.baseURL = getMoquiBaseURL();
+  }
+
+  if(isMoquiAuthBackend() && customConfig.url === "getPermissions") {
+    config.url = "admin/user/permissions";
+    config.method = "get";
+    config.params = customConfig.params || customConfig.data;
+    delete config.data;
+    config.baseURL = getMoquiBaseURL();
+  }
+
   if (customConfig.cache) config.adapter = axiosCache.adapter;
 
+  return config;
+}
+
+const api = async (customConfig: any) => {
+  const config = prepareApiConfig(customConfig);
   return axios(config);
 }
 
@@ -141,4 +163,4 @@ const client = (config: any) => {
   return axios.create().request({ paramsSerializer, ...config })
 }
 
-export { api as default, client, axios };
+export { api as default, client, axios, prepareApiConfig, isAuthBypassEndpoint };

--- a/common/index.ts
+++ b/common/index.ts
@@ -20,6 +20,7 @@ import { useNotificationStore } from './store/notification'
 import { useEmbeddedAppStore } from './store/embeddedApp'
 import { initialiseConfig } from './core/configRegistry'
 import { useAuth } from './composables/useAuth'
+import { getAuthBackend, getMoquiBaseURL, isMoquiAuthBackend } from './core/authBackend'
 
 // ✅ These are pure types (erased during build)
 export { api, client, axios }
@@ -44,5 +45,8 @@ export {
   translate,
   useNotificationStore,
   useEmbeddedAppStore,
-  useAuth
+  useAuth,
+  getAuthBackend,
+  getMoquiBaseURL,
+  isMoquiAuthBackend
 }

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -9,6 +9,7 @@ import Encoding from 'encoding-japanese';
 import cronParser from "cron-parser";
 import cronstrue from "cronstrue"
 import { useEmbeddedAppStore } from "../store/embeddedApp";
+import { getMoquiBaseURL, isMoquiAuthBackend } from "../core/authBackend";
 
 export interface JsonToCsvOption {
   parse?: object | null;
@@ -370,6 +371,9 @@ const getMaargURL = () => {
   let maargURL = ""
   if (maarg) {
     maargURL = maarg.startsWith('http') ? maarg.includes('/rest/s1') ? maarg : `${maarg}/rest/s1/` : `https://${maarg}.hotwax.io/rest/s1/`;
+  }
+  if (isMoquiAuthBackend()) {
+    maargURL = getMoquiBaseURL();
   }
   return maargURL
 }


### PR DESCRIPTION
## Business Summary
This makes local AccxUI development easier by letting developers point the shared auth flow at a local Moqui server, while keeping the existing OFBiz login flow as the default for released apps.

Closes #48

## What Changed
- Added `VITE_AUTH_BACKEND=moqui` support for local Moqui login.
- Kept OFBiz login as the default when the env var is not set.
- Added `VITE_MOQUI_BASE_URL` handling for local Moqui REST URLs.
- Mapped permissions calls to Moqui's `admin/user/permissions` endpoint in Moqui mode.
- Added focused tests for auth backend selection and API config mapping.

## Where To Review
- `common/core/authBackend.ts`: env switch and Moqui URL handling
- `common/composables/useAuth.ts`: login, logout, and login-options flow
- `common/core/remoteApi.ts`: API base URL and permissions mapping
- `common/core/*spec.ts`: focused test coverage

## Validation
- `pnpm exec vitest run common/core/authBackend.spec.ts common/core/remoteApi.spec.ts`
