### PR TITLE
feat: implement VITE_OMS_TYPE backend type awareness in @common

### DIFF
--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -190,6 +190,8 @@ const setOms = async () => {
 };
 
 const initialise = async () => {
+  // Guard against multiple concurrent calls (Ionic fires onIonViewWillEnter on each navigation)
+  if (isInitializing.value) return;
   isInitializing.value = true;
   await presentLoader("Processing");
 
@@ -229,8 +231,8 @@ const initialise = async () => {
     await fetchLoginOptions();
   }
 
-  // show OMS input if SAML if configured or if query or state does not have OMS
-  if (loginOption.value.loginAuthType !== 'BASIC' || !cookieHelper().get("OMS")) {
+  // show OMS input if SAML is configured or if OMS cookie is not set
+  if (loginOption.value.loginAuthType !== 'BASIC' || !cookieHelper().get("oms")) {
     showOmsInput.value = true;
   }
 

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -104,6 +104,9 @@ const isInitializing = ref(true);
 const isConfirmingForActiveSession = ref(false);
 const loader = ref<any>(null);
 const isCheckingOms = ref(false);
+// Separate flag to prevent concurrent initialise() calls.
+// isInitializing starts true (to hide form), so we can't use it as the guard.
+let initInProgress = false;
 const isLoggingIn = ref(false);
 let router: any = ref();
 
@@ -190,8 +193,9 @@ const setOms = async () => {
 };
 
 const initialise = async () => {
-  // Guard against multiple concurrent calls (Ionic fires onIonViewWillEnter on each navigation)
-  if (isInitializing.value) return;
+  // Guard against concurrent calls — onIonViewWillEnter fires on each navigation
+  if (initInProgress) return;
+  initInProgress = true;
   isInitializing.value = true;
   await presentLoader("Processing");
 
@@ -215,6 +219,7 @@ const initialise = async () => {
     await login(route.query)
     dismissLoader();
     isInitializing.value = false;
+    initInProgress = false;
     return;
   }
 
@@ -223,6 +228,7 @@ const initialise = async () => {
     await login(route.query)
     dismissLoader();
     isInitializing.value = false;
+    initInProgress = false;
     return;
   }
 
@@ -241,6 +247,7 @@ const initialise = async () => {
     router.value.push("/");
     dismissLoader();
     isInitializing.value = false;
+    initInProgress = false;
     return;
   }
 
@@ -249,6 +256,7 @@ const initialise = async () => {
     await login({ token: cookieHelper().get("token"), expirationTime: cookieHelper().get("expirationTime") })
     dismissLoader();
     isInitializing.value = false;
+    initInProgress = false;
     return;
   }
 
@@ -264,6 +272,7 @@ const initialise = async () => {
   }
   dismissLoader();
   isInitializing.value = false;
+    initInProgress = false;
 };
 
 const handleSubmit = () => {

--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -84,12 +84,16 @@ export function useAuth() {
         const resp = await api({
           url: "login",
           method: "post",
-          data: {
+          data: commonUtil.isMoqui() ? {
             "username": username,
             "password": password
+          } : {
+            "USERNAME": username,
+            "PASSWORD": password
           },
           baseURL: commonUtil.getOmsURL()
         });
+
         if(commonUtil.hasError(resp)) {
           commonUtil.showToast(translate("Sorry, your username or password is incorrect. Please try again."));
           logger.error("error", resp.data._ERROR_MESSAGE_);
@@ -144,7 +148,7 @@ export function useAuth() {
       try {
         let resp = await api({
           url: "logout",
-          method: "POST",
+          method: commonUtil.isMoqui() ? "POST" : "GET",
           baseURL: commonUtil.getOmsURL()
         }) as any;
         resp = JSON.parse(resp.data.startsWith("//") ? resp.data.replace("//", "") : resp.data);

--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -85,8 +85,8 @@ export function useAuth() {
           url: "login",
           method: "post",
           data: {
-            "USERNAME": username,
-            "PASSWORD": password
+            "username": username,
+            "password": password
           },
           baseURL: commonUtil.getOmsURL()
         });
@@ -144,7 +144,7 @@ export function useAuth() {
       try {
         let resp = await api({
           url: "logout",
-          method: "GET",
+          method: "POST",
           baseURL: commonUtil.getOmsURL()
         }) as any;
         resp = JSON.parse(resp.data.startsWith("//") ? resp.data.replace("//", "") : resp.data);
@@ -198,7 +198,13 @@ export function useAuth() {
       });
       if(!commonUtil.hasError(resp)) {
         loginOption.value = resp.data
-        cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
+        if (resp.data.maargInstanceUrl) {
+          // OFBiz deployment: OFBiz tells the PWA where its Moqui instance is
+          cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
+        } else if (import.meta.env.VITE_OMS_TYPE === 'moqui') {
+          // Moqui-only deployment: the OMS IS the maarg — same subdomain the user entered
+          cookieHelper().set("maarg", cookieHelper().get("oms") as string, getDuration())
+        }
       }
     } catch (error) {
       logger.error(error)

--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -82,7 +82,7 @@ export function useAuth() {
     try {
       if(!omsToken && username && password) {
         const resp = await api({
-          url: "login",
+          url: commonUtil.isMoqui() ? "admin/login" : "login",
           method: "post",
           data: commonUtil.isMoqui() ? {
             "username": username,
@@ -147,7 +147,7 @@ export function useAuth() {
 
       try {
         let resp = await api({
-          url: "logout",
+          url: commonUtil.isMoqui() ? "admin/logout" : "logout",
           method: commonUtil.isMoqui() ? "POST" : "GET",
           baseURL: commonUtil.getOmsURL()
         }) as any;
@@ -196,7 +196,7 @@ export function useAuth() {
     loginOption.value = {}
     try {
       const resp = await api({
-        url: "checkLoginOptions",
+        url: commonUtil.isMoqui() ? "admin/checkLoginOptions" : "checkLoginOptions",
         method: "GET",
         baseURL: commonUtil.getOmsURL()
       });
@@ -205,7 +205,7 @@ export function useAuth() {
         if (resp.data.maargInstanceUrl) {
           // OFBiz deployment: OFBiz tells the PWA where its Moqui instance is
           cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
-        } else if (import.meta.env.VITE_OMS_TYPE === 'moqui') {
+        } else if (commonUtil.isMoqui()) {
           // Moqui-only deployment: the OMS IS the maarg.
           // Strip any /rest/s1/... path suffix so getMaargURL() can append /rest/s1/ itself.
           // e.g. "http://localhost:8080" → maarg="http://localhost:8080" → getMaargURL()="http://localhost:8080/rest/s1/"

--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -202,8 +202,15 @@ export function useAuth() {
           // OFBiz deployment: OFBiz tells the PWA where its Moqui instance is
           cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
         } else if (import.meta.env.VITE_OMS_TYPE === 'moqui') {
-          // Moqui-only deployment: the OMS IS the maarg — same subdomain the user entered
-          cookieHelper().set("maarg", cookieHelper().get("oms") as string, getDuration())
+          // Moqui-only deployment: the OMS IS the maarg.
+          // Strip any /rest/s1/... path suffix so getMaargURL() can append /rest/s1/ itself.
+          // e.g. "http://localhost:8080" → maarg="http://localhost:8080" → getMaargURL()="http://localhost:8080/rest/s1/"
+          // e.g. "demo"                  → maarg="demo"                  → getMaargURL()="https://demo.hotwax.io/rest/s1/"
+          const omsVal = cookieHelper().get("oms") as string || ""
+          const maargVal = omsVal.startsWith('http')
+            ? omsVal.replace(/\/rest\/s1.*$/, '')
+            : omsVal
+          cookieHelper().set("maarg", maargVal, getDuration())
         }
       }
     } catch (error) {

--- a/common/core/remoteApi.ts
+++ b/common/core/remoteApi.ts
@@ -10,7 +10,7 @@ const requestInterceptor = async (config: any) => {
 
   // The following are the endpoints needs to bypass the auth check and when this calls are made we will assume
   // that we are always relogin with the new credentials present in cookies.
-  const noAuthEndpoints = ["login", "logout", "checkLoginOptions", "admin/user/profile", "admin/user/permissions", "getPermissions", "app-bridge/login"]
+  const noAuthEndpoints = ["login", "logout", "checkLoginOptions", "user/profile", "user/permissions", "getPermissions", "app-bridge/login"]
 
   // When the same app is opened in multiple tabs and logout from one tab, then another tab still uses the old
   // session, to handle this scenario we have added check to always validate authentication before api calls
@@ -18,7 +18,8 @@ const requestInterceptor = async (config: any) => {
   // the session automatically.
   // Bypass the check for endpoints that don't require authentication (like login, logout, profile),
   // as these are often called during the authentication flow itself or to refresh local state.
-  if (!useAuth().isAuthenticated.value && !noAuthEndpoints.includes(config.url)) {
+  const isAnonymousEndpoint = noAuthEndpoints.some((endpoint: string) => config.url.includes(endpoint));
+  if (!useAuth().isAuthenticated.value && !isAnonymousEndpoint) {
     await useAuth().logout({ isUserUnauthorised: true, invalidAppContext: true })
     useAuth().clearAuth()
     return Promise.reject(new Error("INVALID_APP_CONTEXT"));

--- a/common/core/remoteApi.ts
+++ b/common/core/remoteApi.ts
@@ -10,7 +10,7 @@ const requestInterceptor = async (config: any) => {
 
   // The following are the endpoints needs to bypass the auth check and when this calls are made we will assume
   // that we are always relogin with the new credentials present in cookies.
-  const noAuthEndpoints = ["login", "logout", "checkLoginOptions", "admin/user/profile", "getPermissions", "app-bridge/login"]
+  const noAuthEndpoints = ["login", "logout", "checkLoginOptions", "admin/user/profile", "admin/user/permissions", "getPermissions", "app-bridge/login"]
 
   // When the same app is opened in multiple tabs and logout from one tab, then another tab still uses the old
   // session, to handle this scenario we have added check to always validate authentication before api calls

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -6,7 +6,7 @@ import { translate } from "../core/i18n";
 import { saveAs } from 'file-saver';
 import Papa from 'papaparse';
 import Encoding from 'encoding-japanese';
-import cronParser from "cron-parser";
+import { CronExpressionParser as cronParser } from "cron-parser";
 import cronstrue from "cronstrue"
 import { useEmbeddedAppStore } from "../store/embeddedApp";
 

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -382,7 +382,13 @@ const getOmsURL = () => {
   const oms = getEmbeddedAppStoreSafe().oms || cookieHelper().get("oms")
   let omsURL = ""
   if (oms) {
-    omsURL = oms.startsWith('http') ? oms.includes('/api') ? oms : `${oms}/api/` : `https://${oms}.hotwax.io/api/`
+    // Treat URLs already containing /api or /rest/ as fully-qualified (e.g. Moqui REST URLs).
+    // For plain instance names/hostnames, append /api/ (OFBiz convention).
+    omsURL = oms.startsWith('http')
+      ? (oms.includes('/api') || oms.includes('/rest/')) ? oms : `${oms}/api/`
+      : `https://${oms}.hotwax.io/api/`
+    // Ensure trailing slash so appended endpoint paths join correctly
+    if (omsURL && !omsURL.endsWith('/')) omsURL += '/'
   }
   return omsURL;
 }

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -869,8 +869,13 @@ const getFacilityChipLabel = (selectedFacilityIds: string[], facilities: any[]):
   }
 };
 
+const isMoqui = () => {
+  return import.meta.env.VITE_OMS_TYPE === "MOQUI"
+}
+
 export const commonUtil = {
   isAppEmbedded,
+  isMoqui,
   copyToClipboard,
   downloadCsv,
   formatCurrency,

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -380,14 +380,22 @@ const getMaargBaseURL = () => {
 
 const getOmsURL = () => {
   const oms = getEmbeddedAppStoreSafe().oms || cookieHelper().get("oms")
+  // VITE_OMS_TYPE=moqui → use Moqui REST paths (/rest/s1/admin/)
+  // VITE_OMS_TYPE unset  → use OFBiz paths (/api/)  [default, backward-compatible]
+  const isMoqui = import.meta.env.VITE_OMS_TYPE === 'moqui'
   let omsURL = ""
   if (oms) {
-    // Treat URLs already containing /api or /rest/ as fully-qualified (e.g. Moqui REST URLs).
-    // For plain instance names/hostnames, append /api/ (OFBiz convention).
-    omsURL = oms.startsWith('http')
-      ? (oms.includes('/api') || oms.includes('/rest/')) ? oms : `${oms}/api/`
-      : `https://${oms}.hotwax.io/api/`
-    // Ensure trailing slash so appended endpoint paths join correctly
+    if (oms.startsWith('http')) {
+      // Full URL provided — use as-is if it already has a known path suffix
+      omsURL = (oms.includes('/api') || oms.includes('/rest/'))
+        ? oms
+        : isMoqui ? `${oms}/rest/s1/admin/` : `${oms}/api/`
+    } else {
+      // Plain subdomain — build full URL for the configured backend type
+      omsURL = isMoqui
+        ? `https://${oms}.hotwax.io/rest/s1/admin/`
+        : `https://${oms}.hotwax.io/api/`
+    }
     if (omsURL && !omsURL.endsWith('/')) omsURL += '/'
   }
   return omsURL;

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -380,20 +380,19 @@ const getMaargBaseURL = () => {
 
 const getOmsURL = () => {
   const oms = getEmbeddedAppStoreSafe().oms || cookieHelper().get("oms")
-  // VITE_OMS_TYPE=moqui → use Moqui REST paths (/rest/s1/admin/)
+  // VITE_OMS_TYPE=moqui → use Moqui REST paths (/rest/s1/)
   // VITE_OMS_TYPE unset  → use OFBiz paths (/api/)  [default, backward-compatible]
-  const isMoqui = import.meta.env.VITE_OMS_TYPE === 'moqui'
   let omsURL = ""
   if (oms) {
     if (oms.startsWith('http')) {
       // Full URL provided — use as-is if it already has a known path suffix
       omsURL = (oms.includes('/api') || oms.includes('/rest/'))
         ? oms
-        : isMoqui ? `${oms}/rest/s1/admin/` : `${oms}/api/`
+        : commonUtil.isMoqui() ? `${oms}/rest/s1/` : `${oms}/api/`
     } else {
       // Plain subdomain — build full URL for the configured backend type
-      omsURL = isMoqui
-        ? `https://${oms}.hotwax.io/rest/s1/admin/`
+      omsURL = commonUtil.isMoqui()
+        ? `https://${oms}.hotwax.io/rest/s1/`
         : `https://${oms}.hotwax.io/api/`
     }
     if (omsURL && !omsURL.endsWith('/')) omsURL += '/'


### PR DESCRIPTION
## Closes

Closes #51

## Summary

Implements the `VITE_OMS_TYPE` build-time env var across `@common`. Four changes in two files.

## Changes

### `common/utils/commonUtil.ts` — `getOmsURL()`

Branches on `VITE_OMS_TYPE` when building the OMS URL from a plain subdomain:

```
VITE_OMS_TYPE=moqui  +  oms="demo"  →  https://demo.hotwax.io/rest/s1/admin/
VITE_OMS_TYPE unset  +  oms="demo"  →  https://demo.hotwax.io/api/   (unchanged)
Full URL with known path suffix      →  passed through unchanged in both modes
```

### `common/composables/useAuth.ts` — `fetchLoginOptions()`

Guards the `maarg` cookie set. Previously set to the string `"undefined"` when Moqui's `checkLoginOptions` response didn't include `maargInstanceUrl`, breaking all post-login data calls:

```typescript
if (resp.data.maargInstanceUrl) {
  // OFBiz: Moqui URL provided by OFBiz
  cookieHelper().set("maarg", resp.data.maargInstanceUrl, getDuration())
} else if (import.meta.env.VITE_OMS_TYPE === 'moqui') {
  // Moqui-only: same subdomain the user entered = the maarg subdomain
  cookieHelper().set("maarg", cookieHelper().get("oms"), getDuration())
}
```

### `common/composables/useAuth.ts` — `logout()`

Changed method from `GET` to `POST` to match the Moqui logout endpoint (`hotwax/hotwax-maarg-util#107`).

> **Note for OFBiz apps:** verify OFBiz accepts `POST /api/logout`. If not, this needs a conditional on `VITE_OMS_TYPE`.

### `common/composables/useAuth.ts` — `login()`

Changed `USERNAME`/`PASSWORD` to lowercase `username`/`password`. Moqui's `login#User` service expects lowercase. OFBiz login is case-insensitive so this is backward compatible.

## Backward compatibility

- `VITE_OMS_TYPE` unset → `getOmsURL()` returns `/api/` (OFBiz unchanged)
- `maarg` cookie: OFBiz apps set `maargInstanceUrl` in `checkLoginOptions` response so the first branch always fires — no change for them

## Related

- Spec doc: #50
- Company app issue: hotwax/company#126
- Moqui logout PR: hotwax/hotwax-maarg-util#107