### PR TITLE
Use browser language preference as locale default

### DIFF
--- a/common/core/i18n.ts
+++ b/common/core/i18n.ts
@@ -1,14 +1,39 @@
 import { createI18n } from "vue-i18n"
+import { cookieHelper } from "../helpers/cookieHelper"
 
 let i18n: any
 let translate: any
 
+function findBestLocale(supportedLocales: string[]): string | null {
+  if (typeof navigator === 'undefined') return null;
+  const userLocales = navigator.languages || [navigator.language];
+  for (const locale of userLocales) {
+    const normLocale = locale.toLowerCase();
+    const exactMatch = supportedLocales.find(s => s.toLowerCase() === normLocale);
+    if (exactMatch) return exactMatch;
+
+    const baseLang = normLocale.split('-')[0];
+    const prefixMatch = supportedLocales.find(s => s.split('-')[0].toLowerCase() === baseLang);
+    if (prefixMatch) return prefixMatch;
+  }
+  return null;
+}
+
 // Factory function to initialize with app’s locales
 export function createDxpI18n(localeMessages: Record<string, any>) {
+  const cookie = cookieHelper();
+  const savedLocale = cookie.get('locale');
+  const envLocale = import.meta.env.VITE_I18N_LOCALE;
+  const supportedLocales = Object.keys(localeMessages);
+  const navigatorLocale = findBestLocale(supportedLocales);
+  const defaultFallback = import.meta.env.VITE_I18N_FALLBACK_LOCALE || 'en-US';
+
+  const selectedLocale = savedLocale || envLocale || navigatorLocale || defaultFallback;
+
   i18n = createI18n({
     legacy: false,
-    locale: import.meta.env.VITE_I18N_LOCALE || 'en-US',
-    fallbackLocale: import.meta.env.VITE_I18N_FALLBACK_LOCALE || 'en-US',
+    locale: selectedLocale,
+    fallbackLocale: defaultFallback,
     messages: localeMessages
   })
 

--- a/common/core/i18n.ts
+++ b/common/core/i18n.ts
@@ -6,7 +6,10 @@ let translate: any
 
 function findBestLocale(supportedLocales: string[]): string | null {
   if (typeof navigator === 'undefined') return null;
-  const userLocales = navigator.languages || [navigator.language];
+  const rawLocales = navigator.languages && navigator.languages.length > 0
+    ? navigator.languages
+    : [navigator.language];
+  const userLocales = rawLocales.filter((l): l is string => typeof l === 'string' && l.length > 0);
   for (const locale of userLocales) {
     const normLocale = locale.toLowerCase();
     const exactMatch = supportedLocales.find(s => s.toLowerCase() === normLocale);
@@ -22,7 +25,7 @@ function findBestLocale(supportedLocales: string[]): string | null {
 // Factory function to initialize with app’s locales
 export function createDxpI18n(localeMessages: Record<string, any>) {
   const cookie = cookieHelper();
-  const savedLocale = cookie.get('locale');
+  const savedLocale = typeof document !== 'undefined' ? cookie.get('locale') : null;
   const envLocale = import.meta.env.VITE_I18N_LOCALE;
   const supportedLocales = Object.keys(localeMessages);
   const navigatorLocale = findBestLocale(supportedLocales);

--- a/common/core/i18n.ts
+++ b/common/core/i18n.ts
@@ -9,18 +9,18 @@ function findBestLocale(supportedLocales: string[]): string | null {
     const exactMatch = supportedLocales.find(s => s.toLowerCase() === normLocale);
     if (exactMatch) return exactMatch;
 
-    const baseLang = normLocale.split(‘-’)[0];
-    const prefixMatch = supportedLocales.find(s => s.split(‘-’)[0].toLowerCase() === baseLang);
+    const baseLang = normLocale.split('-')[0];
+    const prefixMatch = supportedLocales.find(s => s.split('-')[0].toLowerCase() === baseLang);
     if (prefixMatch) return prefixMatch;
   }
   return null;
 }
 
-// Factory function to initialize with app’s locales
+// Factory function to initialize with app's locales
 export function createDxpI18n(localeMessages: Record<string, any>) {
   const supportedLocales = Object.keys(localeMessages);
   const navigatorLocale = findBestLocale(supportedLocales);
-  const defaultFallback = import.meta.env.VITE_I18N_FALLBACK_LOCALE || ‘en-US’;
+  const defaultFallback = import.meta.env.VITE_I18N_FALLBACK_LOCALE || 'en-US';
 
   const selectedLocale = navigatorLocale || defaultFallback;
 

--- a/common/core/i18n.ts
+++ b/common/core/i18n.ts
@@ -1,22 +1,16 @@
 import { createI18n } from "vue-i18n"
-import { cookieHelper } from "../helpers/cookieHelper"
 
 let i18n: any
 let translate: any
 
 function findBestLocale(supportedLocales: string[]): string | null {
-  if (typeof navigator === 'undefined') return null;
-  const rawLocales = navigator.languages && navigator.languages.length > 0
-    ? navigator.languages
-    : [navigator.language];
-  const userLocales = rawLocales.filter((l): l is string => typeof l === 'string' && l.length > 0);
-  for (const locale of userLocales) {
+  for (const locale of navigator.languages) {
     const normLocale = locale.toLowerCase();
     const exactMatch = supportedLocales.find(s => s.toLowerCase() === normLocale);
     if (exactMatch) return exactMatch;
 
-    const baseLang = normLocale.split('-')[0];
-    const prefixMatch = supportedLocales.find(s => s.split('-')[0].toLowerCase() === baseLang);
+    const baseLang = normLocale.split(‘-’)[0];
+    const prefixMatch = supportedLocales.find(s => s.split(‘-’)[0].toLowerCase() === baseLang);
     if (prefixMatch) return prefixMatch;
   }
   return null;
@@ -24,14 +18,11 @@ function findBestLocale(supportedLocales: string[]): string | null {
 
 // Factory function to initialize with app’s locales
 export function createDxpI18n(localeMessages: Record<string, any>) {
-  const cookie = cookieHelper();
-  const savedLocale = typeof document !== 'undefined' ? cookie.get('locale') : null;
-  const envLocale = import.meta.env.VITE_I18N_LOCALE;
   const supportedLocales = Object.keys(localeMessages);
   const navigatorLocale = findBestLocale(supportedLocales);
-  const defaultFallback = import.meta.env.VITE_I18N_FALLBACK_LOCALE || 'en-US';
+  const defaultFallback = import.meta.env.VITE_I18N_FALLBACK_LOCALE || ‘en-US’;
 
-  const selectedLocale = savedLocale || envLocale || navigatorLocale || defaultFallback;
+  const selectedLocale = navigatorLocale || defaultFallback;
 
   i18n = createI18n({
     legacy: false,

--- a/common/core/i18n.ts
+++ b/common/core/i18n.ts
@@ -5,13 +5,8 @@ let translate: any
 
 function findBestLocale(supportedLocales: string[]): string | null {
   for (const locale of navigator.languages) {
-    const normLocale = locale.toLowerCase();
-    const exactMatch = supportedLocales.find(s => s.toLowerCase() === normLocale);
+    const exactMatch = supportedLocales.find(s => s.toLowerCase() === locale.toLowerCase());
     if (exactMatch) return exactMatch;
-
-    const baseLang = normLocale.split('-')[0];
-    const prefixMatch = supportedLocales.find(s => s.split('-')[0].toLowerCase() === baseLang);
-    if (prefixMatch) return prefixMatch;
   }
   return null;
 }


### PR DESCRIPTION
## What

Use the browser's language preference (`navigator.languages`) to set the app locale instead of always defaulting to `en-US`.

`findBestLocale` walks the user's browser languages and matches against the app's supported locales by exact (case-insensitive) match — supported locales always follow the `language-region` pattern (e.g. `en-US`). If no match, falls back to `VITE_I18N_FALLBACK_LOCALE` or `en-US`.

## Test plan

- [ ] Set browser language to a supported locale (e.g. `ja-JP`) — app should load in that language
- [ ] Set browser language to an unsupported locale — app should fall back to `en-US`

🤖 Generated with [Claude Code](https://claude.com/claude-code)