### PR TITLE
feat: add parseDateTimeValue and formatDateTimeValue to commonUtil

### DIFF
--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -852,6 +852,52 @@ const formatDateTime = (dateStr: string, format?: string | null, endOfDay = fals
   return format ? final.toFormat(format) : final.toFormat("yyyy-MM-dd HH:mm:ss.SSS");
 }
 
+/**
+ * Parses any date/time value returned by Moqui or OFBiz into a Luxon DateTime.
+ * Handles: Luxon DateTime passthrough, epoch milliseconds (number or numeric string),
+ * ISO 8601, SQL timestamp, RFC 2822, HTTP date, and common custom format strings.
+ * Returns null when the value is empty or cannot be parsed.
+ */
+const parseDateTimeValue = (value: any): DateTime | null => {
+  if (!value) return null
+  if (DateTime.isDateTime(value)) return value as DateTime
+  if (typeof value === 'number') {
+    const dt = DateTime.fromMillis(value)
+    return dt.isValid ? dt : null
+  }
+  if (typeof value !== 'string') return null
+  if (/^\d+$/.test(value)) {
+    const dt = DateTime.fromMillis(Number(value))
+    return dt.isValid ? dt : null
+  }
+  const norm = value.replace(/^[A-Za-z]{3},\s*/, '')
+  const candidates = [
+    DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm:ssZZ"),
+    DateTime.fromFormat(value, 'yyyy-MM-dd HH:mm:ss.SSS'),
+    DateTime.fromSQL(value),
+    DateTime.fromISO(value),
+    DateTime.fromRFC2822(value),
+    DateTime.fromHTTP(value),
+    DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss ZZZ'),
+    DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss z'),
+  ]
+  return candidates.find(c => c.isValid) ?? null
+}
+
+/**
+ * General-purpose display formatter. Parses any date/time value with
+ * parseDateTimeValue and formats it for display. Default output is
+ * DateTime.DATETIME_MED locale string (e.g. "Jun 4, 2026, 10:30 AM").
+ * Named formatDateTimeValue to distinguish from the existing formatDateTime
+ * which is an ISO date-range helper with a different signature.
+ */
+const formatDateTimeValue = (value: any, format?: string): string => {
+  if (!value) return ''
+  const dt = parseDateTimeValue(value)
+  if (!dt || !dt.isValid) return ''
+  return format ? dt.toFormat(format) : dt.toLocaleString(DateTime.DATETIME_MED)
+}
+
 function getDateTimeWithOrdinalSuffix(time: any) {
   if (!time) return "-";
   const dateTime = DateTime.fromMillis(time);
@@ -882,6 +928,8 @@ export const commonUtil = {
   formatCurrency,
   formatDate,
   formatDateTime,
+  formatDateTimeValue,
+  parseDateTimeValue,
   formatPhoneNumber,
   formatUtcDate,
   generateInternalId,

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -871,17 +871,21 @@ const parseDateTimeValue = (value: any): DateTime | null => {
     return dt.isValid ? dt : null
   }
   const norm = value.replace(/^[A-Za-z]{3},\s*/, '')
-  const candidates = [
-    DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm:ssZZ"),
-    DateTime.fromFormat(value, 'yyyy-MM-dd HH:mm:ss.SSS'),
-    DateTime.fromSQL(value),
-    DateTime.fromISO(value),
-    DateTime.fromRFC2822(value),
-    DateTime.fromHTTP(value),
-    DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss ZZZ'),
-    DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss z'),
+  const parsers = [
+    () => DateTime.fromISO(value),
+    () => DateTime.fromSQL(value),
+    () => DateTime.fromFormat(value, "yyyy-MM-dd'T'HH:mm:ssZZ"),
+    () => DateTime.fromFormat(value, 'yyyy-MM-dd HH:mm:ss.SSS'),
+    () => DateTime.fromRFC2822(value),
+    () => DateTime.fromHTTP(value),
+    () => DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss ZZZ'),
+    () => DateTime.fromFormat(norm, 'dd LLL yyyy HH:mm:ss z'),
   ]
-  return candidates.find(c => c.isValid) ?? null
+  for (const parse of parsers) {
+    const dt = parse()
+    if (dt.isValid) return dt
+  }
+  return null
 }
 
 /**
@@ -894,7 +898,7 @@ const parseDateTimeValue = (value: any): DateTime | null => {
 const formatDateTimeValue = (value: any, format?: string): string => {
   if (!value) return ''
   const dt = parseDateTimeValue(value)
-  if (!dt || !dt.isValid) return ''
+  if (!dt) return ''
   return format ? dt.toFormat(format) : dt.toLocaleString(DateTime.DATETIME_MED)
 }
 


### PR DESCRIPTION
## Summary

- Adds `commonUtil.parseDateTimeValue(value)` — parses any date/time format returned by Moqui or OFBiz (epoch millis as number or numeric string, ISO 8601, SQL timestamp, RFC 2822, HTTP date, multiple custom format strings) into a Luxon `DateTime`. Returns `null` for empty or unparseable inputs.
- Adds `commonUtil.formatDateTimeValue(value, format?)` — wraps `parseDateTimeValue` for display use; defaults to `DateTime.DATETIME_MED` locale string. Named `formatDateTimeValue` to avoid collision with the existing `formatDateTime` date-range helper.

Closes #61

## Background

The `company` app has had local copies of these utilities in `src/utils/index.ts` since the migration from Vue CLI. Bani Manna flagged this in PR #132 — per the accxUI standard, generic utilities that belong in the shared package should not be duplicated per-app.

The existing `commonUtil.formatDateTime` is an ISO-only date-range helper with a different signature and output format; these new functions serve a different purpose (general-purpose backend-response parsing + display).

## Test plan

- [ ] `parseDateTimeValue` handles: `null`/`undefined`/empty → `null`; Luxon `DateTime` passthrough; `number` → `fromMillis`; numeric string → `fromMillis`; ISO 8601 string; SQL timestamp (`yyyy-MM-dd HH:mm:ss.SSS`); RFC 2822; HTTP date
- [ ] `formatDateTimeValue` returns empty string for empty input; locale string for valid input; custom format when `format` arg provided
- [ ] `company` app can replace local imports with `commonUtil.parseDateTimeValue` / `commonUtil.formatDateTimeValue` after this merges