### PR TITLE
Add shared UI summary components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ logs/
 !.env.example
 
 apps/
+.gstack/

--- a/common/components/RadioFacetGroup.vue
+++ b/common/components/RadioFacetGroup.vue
@@ -1,0 +1,85 @@
+<template>
+  <ion-radio-group :value="modelValue" @ionChange="onChange">
+    <div class="radio-facets">
+      <ion-item lines="none" v-for="opt in options" :key="opt.value">
+        <ion-radio :value="opt.value" :label-placement="labelPlacement" :disabled="opt.disabled">
+          <slot name="option" :option="opt">
+            <ion-label class="ion-text-wrap">
+              {{ opt.primary }}
+              <p v-if="opt.secondary">{{ opt.secondary }}</p>
+              <p v-if="opt.meta" class="meta">{{ opt.meta }}</p>
+            </ion-label>
+          </slot>
+        </ion-radio>
+      </ion-item>
+    </div>
+  </ion-radio-group>
+</template>
+
+<script lang="ts" setup>
+import { IonItem, IonLabel, IonRadio, IonRadioGroup } from '@ionic/vue';
+import type { PropType } from 'vue';
+import { defineEmits, defineProps } from 'vue';
+
+type LabelPlacement = 'end' | 'fixed' | 'start' | 'stacked';
+
+interface RadioFacetOption {
+  value: string | number;
+  primary: string;
+  secondary?: string;
+  meta?: string;
+  disabled?: boolean;
+}
+
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: ''
+  },
+  options: {
+    type: Array as () => RadioFacetOption[],
+    default: () => []
+  },
+  labelPlacement: {
+    type: String as PropType<LabelPlacement>,
+    default: 'end'
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'change']);
+
+const onChange = (event: CustomEvent) => {
+  const value = event.detail.value;
+  emit('update:modelValue', value);
+  emit('change', value);
+};
+</script>
+
+<style scoped>
+.radio-facets {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: scroll;
+  gap: var(--spacer-xs);
+  margin: 8px 0 6px;
+}
+
+.radio-facets > ion-item {
+  flex: 1 0 100%;
+  max-width: fit-content;
+  border: var(--border-medium);
+  border-radius: 10px;
+}
+
+.radio-facets ion-item:first-child {
+  margin-left: var(--spacer-sm);
+}
+
+.radio-facets ion-item:last-child {
+  margin-right: var(--spacer-sm);
+}
+
+.meta {
+  opacity: 0.6;
+}
+</style>

--- a/common/components/Sparkline.vue
+++ b/common/components/Sparkline.vue
@@ -1,0 +1,80 @@
+<template>
+  <!--
+    Lightweight inline trendline (spark line). Normalizes `points` to the
+    viewBox automatically, so callers just pass raw values.
+  -->
+  <div class="sparkline-container" :style="{ height: `${height}px` }">
+    <svg
+      class="sparkline"
+      :viewBox="`0 0 100 ${height}`"
+      width="100%"
+      :height="height"
+      :stroke="`var(--ion-color-${color})`"
+      :stroke-width="strokeWidth"
+      fill="none"
+      preserveAspectRatio="none"
+    >
+      <polyline :points="polylinePoints" />
+    </svg>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  // Raw data values, plotted left-to-right.
+  points: {
+    type: Array as () => number[],
+    default: () => []
+  },
+  // Ionic color name, resolved to --ion-color-<color>.
+  color: {
+    type: String,
+    default: 'primary'
+  },
+  strokeWidth: {
+    type: Number,
+    default: 2
+  },
+  height: {
+    type: Number,
+    default: 30
+  }
+});
+
+// Maps each value to viewBox coordinates: x spreads evenly across 0..100,
+// y is normalized to the data range and inverted (SVG y grows downward),
+// with a small vertical inset so the stroke isn't clipped at the edges.
+const polylinePoints = computed(() => {
+  const values = props.points;
+  if (!values.length) return '';
+
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+
+  const inset = props.strokeWidth;
+  const usableHeight = props.height - inset * 2;
+  const lastIndex = values.length - 1 || 1;
+
+  return values
+    .map((value, i) => {
+      const x = (i / lastIndex) * 100;
+      const y = inset + (1 - (value - min) / range) * usableHeight;
+      return `${x},${y}`;
+    })
+    .join(' ');
+});
+</script>
+
+<style scoped>
+.sparkline-container {
+  display: flex;
+  align-items: center;
+}
+
+.sparkline {
+  display: block;
+}
+</style>

--- a/common/components/StatCard.vue
+++ b/common/components/StatCard.vue
@@ -1,0 +1,74 @@
+<template>
+  <!--
+    Reusable stat card: an overline title + a prominent "big number" stat,
+    followed by one of three optional follow-ups:
+      1. subtitle  — pass the `subtitle` prop (or the #subtitle slot)
+      2. trendline — drop a <Sparkline> into the default slot
+      3. drilldown — set `button` and drop an <ion-list>/content into the default slot
+  -->
+  <ion-card :button="button" class="stat-card">
+    <ion-card-content>
+      <p v-if="title || $slots.title" class="overline">
+        <slot name="title">{{ title }}</slot>
+      </p>
+
+      <h1 class="stat">
+        <slot name="stat">{{ stat }}</slot>
+      </h1>
+
+      <p v-if="subtitle || $slots.subtitle" class="stat-subtitle">
+        <slot name="subtitle">{{ subtitle }}</slot>
+      </p>
+
+      <div v-if="$slots.default" class="stat-followup">
+        <slot />
+      </div>
+    </ion-card-content>
+  </ion-card>
+</template>
+
+<script lang="ts" setup>
+import { IonCard, IonCardContent } from '@ionic/vue';
+import { defineProps } from 'vue';
+
+defineProps({
+  // Overline label shown above the stat (e.g. "Open Orders").
+  title: {
+    type: String,
+    default: ''
+  },
+  // The primary value — the "big number".
+  stat: {
+    type: [String, Number],
+    default: ''
+  },
+  // Optional caption rendered below the stat (follow-up #1).
+  subtitle: {
+    type: String,
+    default: ''
+  },
+  // Makes the whole card tappable for drilldown navigation.
+  button: {
+    type: Boolean,
+    default: false
+  }
+});
+</script>
+
+<style scoped>
+.stat-card {
+  margin: 0;
+}
+
+.stat {
+  margin: var(--spacer-xs) 0;
+}
+
+.stat-subtitle {
+  margin: 0;
+}
+
+.stat-followup {
+  margin-top: var(--spacer-sm);
+}
+</style>

--- a/common/css/theme.css
+++ b/common/css/theme.css
@@ -8,6 +8,9 @@ body {
   --spacer-xl: 2.5rem;   /* 40px */
   --spacer-2xl: 5rem;    /* 80px */
   --spacer-3xl: 10rem;   /* 160px */
+
+  /** Border variables **/
+  --border-medium: 1px solid var(--ion-color-medium);
 }
 
 ion-split-pane {

--- a/common/index.ts
+++ b/common/index.ts
@@ -1,5 +1,8 @@
 import imagePreview from './directives/imagePreview'
 import DxpShopifyImg from "./components/DxpShopifyImg.vue"
+import RadioFacetGroup from "./components/RadioFacetGroup.vue"
+import StatCard from "./components/StatCard.vue"
+import Sparkline from "./components/Sparkline.vue"
 import Login from "./components/Login.vue"
 import ShopifyLogin from "./components/ShopifyLogin.vue"
 import ShopifyAppInstall from "./components/ShopifyAppInstall.vue"
@@ -36,6 +39,9 @@ export {
   initialiseConfig,
   logger,
   Login,
+  RadioFacetGroup,
+  Sparkline,
+  StatCard,
   ShopifyLogin,
   ShopifyAppInstall,
   moduleFederationUtil,


### PR DESCRIPTION
## Business summary
AccxUI apps need reusable shared UI primitives for compact operational dashboards and filter surfaces, so app teams can compose consistent Ionic screens without rebuilding stat cards, sparklines, or radio-style facets in every app.

Closes #63

## Changes
- Add shared `StatCard`, `Sparkline`, and `RadioFacetGroup` components.
- Export the new components from `common/index.ts`.
- Add a shared border token and ignore local `.gstack/` tooling state.
- Keep `RadioFacetGroup` on plain Ionic-friendly structure without Ionic grid primitives.

## Validation
- `git diff --check` passed.
- `pnpm exec vue-tsc --noEmit --pretty false --skipLibCheck common/components/RadioFacetGroup.vue common/components/Sparkline.vue common/components/StatCard.vue` passed.
- `pnpm lint` is blocked by an existing ESLint 10 / `eslint-plugin-import` `import/order` crash in `common/components/ImageModal.vue`.
- `pnpm build` is blocked by existing workspace-wide module resolution/type errors in app folders; the new component type issue surfaced by that run was fixed.
