### PR TITLE
ci: use --no-frozen-lockfile so build workflows resolve against current app deps

### DIFF
--- a/.github/workflows/common-firebase-hosting-merge.yml
+++ b/.github/workflows/common-firebase-hosting-merge.yml
@@ -53,7 +53,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Generate .env file
         run: cp .env.example .env

--- a/.github/workflows/common-firebase-hosting-release.yml
+++ b/.github/workflows/common-firebase-hosting-release.yml
@@ -58,7 +58,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Generate .env file
         run: cp .env.example .env

--- a/.github/workflows/common-pull-request.yml
+++ b/.github/workflows/common-pull-request.yml
@@ -47,7 +47,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --no-frozen-lockfile
 
     - name: Generate .env file
       run: cp .env.example .env

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         app: ["launchpad", "fulfillment", "bopis", "receiving", "job-manager", "order-routing", "inventory-count", "available-to-promise", "transfers", "facilities", "users", "company", "preorder"]
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --no-frozen-lockfile
 
     - name: Generate .env file
       run: cp .env.example .env


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. -->

#

### Short Description and Why It's Useful

The build/deploy workflows clone each app (`hotwax/<app>`) into `apps/` at run time, then run `pnpm install` — which defaults to `--frozen-lockfile` in CI. Since the apps are separate repos checked out at their default branch, the root `pnpm-lock.yaml` can never stay in sync with every app's `package.json`. So install fails with `ERR_PNPM_OUTDATED_LOCKFILE` **before the build step runs**:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/apps/<app>/package.json
```

This has kept **Verify build** red on `main` and every open PR since the workflow was introduced — so the check currently tells us nothing about whether a PR actually builds.

**Fix:** run `pnpm install --no-frozen-lockfile` so pnpm resolves against the apps' current `package.json` files at build time (this is exactly what the pnpm error message recommends for this case). Applied to all four workflows that clone an app and install:

- `pull-request.yml` — the **Verify build** PR check (the one failing on PRs/main)
- `common-pull-request.yml` — `workflow_call` template
- `common-firebase-hosting-merge.yml` — `workflow_call` template
- `common-firebase-hosting-release.yml` — `workflow_call` template

The three `workflow_call` templates are invoked from the individual app repos and share the identical install step, so they're fixed here for consistency.

### Screenshots of Visual Changes before/after (If There Are Any)

N/A — CI configuration only.

### Is the changes contains any breaking change?

- [ ] Yes
- [x] No

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/hotwax/accxui#contribution-guideline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)