### PR TITLE
[codex] Use Moqui login key for REST auth

### DIFF
--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -14,6 +14,7 @@ const loginOption = ref<LoginOption>({})
 export const omsRef = ref("")
 const token = ref(cookieHelper().get("token") || "")
 const expirationTime = ref(cookieHelper().get("expirationTime") || "")
+const apiKey = ref(cookieHelper().get("api_key") || "")
 
 export function useAuth() {
   const getDuration = (expirationTime?: any) => {
@@ -22,10 +23,18 @@ export function useAuth() {
   }
 
 
-  const updateToken = (newToken: any, newExpirationTime: any) => {
+  const updateToken = (newToken: any, newExpirationTime: any, newApiKey?: any) => {
     const duration = getDuration(newExpirationTime);
     cookieHelper().set("token", newToken, duration)
     cookieHelper().set("expirationTime", newExpirationTime, duration)
+    if (newApiKey !== undefined) {
+      if (newApiKey) {
+        cookieHelper().set("api_key", newApiKey, duration)
+      } else {
+        cookieHelper().remove("api_key")
+      }
+      apiKey.value = newApiKey
+    }
     token.value = newToken
     expirationTime.value = newExpirationTime
   }
@@ -42,9 +51,10 @@ export function useAuth() {
   const clearAuth = () => {
     cookieHelper().remove("token");
     cookieHelper().remove("expirationTime");
+    cookieHelper().remove("api_key");
     cookieHelper().remove("maarg");
     cookieHelper().remove("userId");
-    updateToken("", "")
+    updateToken("", "", "")
     updateOMS("")
     updateUserId("")
   }
@@ -79,6 +89,7 @@ export function useAuth() {
   const login = async (username?: string, password?: string, token?: string, expirationTime?: string) => {
     let omsToken = token
     let expiresAt = expirationTime
+    let loginKey
     try {
       if(!omsToken && username && password) {
         const resp = await api({
@@ -98,16 +109,17 @@ export function useAuth() {
           commonUtil.showToast(translate("Sorry, your username or password is incorrect. Please try again."));
           logger.error("error", resp.data._ERROR_MESSAGE_);
           updateUserId("")
-          updateToken("", "")
+          updateToken("", "", "")
 
           return Promise.reject(new Error(resp.data._ERROR_MESSAGE_));
         }
 
         omsToken = resp.data.token
         expiresAt = resp.data.expirationTime
+        loginKey = commonUtil.isMoqui() ? (resp.data.api_key || "") : undefined
       }
 
-      updateToken(omsToken, expiresAt)
+      updateToken(omsToken, expiresAt, loginKey)
 
       if(accxuiConfig.value.postLogin) {
         await accxuiConfig.value.postLogin();
@@ -117,7 +129,7 @@ export function useAuth() {
         return;
       }
 
-      updateToken("", "")
+      updateToken("", "", "")
       accxuiConfig.value.oms = "",
       accxuiConfig.value.current = {}
 
@@ -162,7 +174,7 @@ export function useAuth() {
     }
 
     if(!payload?.invalidAppContext && !commonUtil.isAppEmbedded()) {
-      updateToken("", "")
+      updateToken("", "", "")
       updateUserId("")
     } else {
       commonUtil.showToast(translate("Session expired. Refreshing..."))

--- a/common/core/remoteApi.ts
+++ b/common/core/remoteApi.ts
@@ -7,6 +7,8 @@ import { useAuth } from '../composables/useAuth';
 
 const requestInterceptor = async (config: any) => {
   const token = commonUtil.getToken();
+  const apiKey = commonUtil.getApiKey();
+  config.headers = config.headers || {};
 
   // The following are the endpoints needs to bypass the auth check and when this calls are made we will assume
   // that we are always relogin with the new credentials present in cookies.
@@ -25,7 +27,10 @@ const requestInterceptor = async (config: any) => {
     return Promise.reject(new Error("INVALID_APP_CONTEXT"));
   }
 
-  if (token) {
+  if (apiKey && commonUtil.isMoqui()) {
+    config.headers["api_key"] = apiKey;
+    config.headers['Content-Type'] = 'application/json';
+  } else if (token) {
     config.headers["Authorization"] = "Bearer " + token;
     config.headers['Content-Type'] = 'application/json';
   }

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -406,6 +406,10 @@ const getToken = () => {
   return getEmbeddedAppStoreSafe().getToken || cookieHelper().get("token")
 }
 
+const getApiKey = () => {
+  return cookieHelper().get("api_key")
+}
+
 const getTokenExpiration = () => {
   return getEmbeddedAppStoreSafe().getTokenExpiration || cookieHelper().get("expirationTime")
 }
@@ -909,6 +913,7 @@ export const commonUtil = {
   getStatusColor,
   getTelecomCountryCode,
   getTime,
+  getApiKey,
   getToken,
   getTokenExpiration,
   goToOms,


### PR DESCRIPTION
## Business summary
Fixes #69.

Product Store onboarding needs protected Moqui REST writes for setup tasks such as access-package assignment and Shopify JWT handoff. The shared AccxUI client was keeping only the login JWT and sending it as a bearer token, but the current Moqui REST auth path accepts the login key through `api_key`/`login_key`. That meant users could log in successfully and still fail when onboarding needed to create or update records.

## What changed
- Store the `api_key` returned by Moqui `admin/login` with the same expiry window as the session token.
- Clear the stored login key on logout, auth clear, and failed login paths.
- Send `api_key` for Moqui REST calls while preserving the existing bearer token behavior for non-Moqui backends.

## Validation
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build` from an AccxUI worktree with Company linked to the Product Store onboarding branch.
- `git diff --check`.
- Chrome smoke against Company on `127.0.0.1:8122` and isolated Moqui on `localhost:8081`: fresh login stored `api_key`, product store reads used `api_key`, and `/rest/s1/admin/jwtTokens` returned 200 from the onboarding JWT handoff UI.

## Notes
- Focused ESLint did not run because the current repo tooling throws inside `eslint-plugin-import` with ESLint 10 (`sourceCode.getTokenOrCommentBefore is not a function`).
