### PR TITLE
Update chrome-ide-trace to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@vitejs/plugin-vue": "catalog:",
     "@vue/eslint-config-typescript": "^12.0.0",
     "@vue/test-utils": "^2.4.6",
+    "chrome-ide-trace": "0.1.1",
     "eslint": "catalog:",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
## Business summary
This app already uses IDE Trace during local development. Updating to chrome-ide-trace 0.1.1 lets developers get the new plugin-started localhost opener server from normal dependency installation, reducing local setup friction and avoiding a separate native host step for the common path.

Closes #73

## Changes
- Updates chrome-ide-trace from ^0.1.0 to ^0.1.1.

## Validation
- Verified chrome-ide-trace@0.1.1 is published as npm latest.
- Package-only change; no app source changed.
