### PR TITLE
Centralize chrome-ide-trace in AccxUI catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@vitejs/plugin-vue": "catalog:",
     "@vue/eslint-config-typescript": "^12.0.0",
     "@vue/test-utils": "^2.4.6",
-    "chrome-ide-trace": "0.1.1",
+    "chrome-ide-trace": "catalog:",
     "eslint": "catalog:",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,7 @@ catalog:
   "vue-tsc": "2.1.10"
   "@vitejs/plugin-legacy": "5.0.0"
   "@vitejs/plugin-vue": "4.6.2"
+  "chrome-ide-trace": "0.1.1"
 
 catalogs:
   ionic7:


### PR DESCRIPTION
Business summary: Centralizes IDE Trace package management so AccxUI controls the installed version once for all linked apps, avoiding app-by-app dependency churn while preserving the existing Vite plugin imports.\n\nCloses https://github.com/hotwax/accxui/issues/75