### PR TITLE
Use chrome-ide-trace catalog range

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ catalog:
   "vue-tsc": "2.1.10"
   "@vitejs/plugin-legacy": "5.0.0"
   "@vitejs/plugin-vue": "4.6.2"
-  "chrome-ide-trace": "0.1.1"
+  "chrome-ide-trace": "^0.1.1"
 
 catalogs:
   ionic7:


### PR DESCRIPTION
Business summary: Keeps IDE Trace dependency management centralized in AccxUI while preserving compatible-version resolution from the workspace catalog for future patch releases.\n\nCloses https://github.com/hotwax/accxui/issues/77