### PR TITLE
Remove obsolete Vue macro imports from shared components

### DIFF
--- a/common/components/ImageModal.vue
+++ b/common/components/ImageModal.vue
@@ -19,7 +19,6 @@
 
 <script lang="ts" setup>
 import { IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonModal, IonTitle, IonToolbar } from '@ionic/vue';
-import { defineProps } from 'vue';
 import { closeOutline } from 'ionicons/icons';
 import DxpShopifyImg from './DxpShopifyImg.vue';
 

--- a/common/components/RadioFacetGroup.vue
+++ b/common/components/RadioFacetGroup.vue
@@ -19,7 +19,6 @@
 <script lang="ts" setup>
 import { IonItem, IonLabel, IonRadio, IonRadioGroup } from '@ionic/vue';
 import type { PropType } from 'vue';
-import { defineEmits, defineProps } from 'vue';
 
 type LabelPlacement = 'end' | 'fixed' | 'start' | 'stacked';
 

--- a/common/components/StatCard.vue
+++ b/common/components/StatCard.vue
@@ -29,7 +29,6 @@
 
 <script lang="ts" setup>
 import { IonCard, IonCardContent } from '@ionic/vue';
-import { defineProps } from 'vue';
 
 defineProps({
   // Overline label shown above the stat (e.g. "Open Orders").


### PR DESCRIPTION
## Summary

- Restores downstream app typechecking under the Vue 3.5 / TypeScript 6 toolchain used by the shared AccxUI verification workflow.
- Removes obsolete `defineProps` and `defineEmits` imports from the three shared components named by the failing workflow.
- Preserves templates, runtime imports, props/emits declarations, styling, and component behavior.

Closes #106.

## Business impact

Order Routing and other AccxUI-based app PRs can reach their own build and test gates instead of failing in shared components before application code is evaluated.

## Evidence

- Issue: https://github.com/hotwax/accxui/issues/106
- Downstream PR: https://github.com/hotwax/order-routing/pull/499
- Repeated failing workflow: https://github.com/hotwax/order-routing/actions/runs/29642142553
- Jam waived: this is a non-visual compiler failure with exact source locations and complete GitHub Actions diagnostics.

## Root cause

Vue compiler macros are already available globally inside `<script setup>`. Explicitly importing them conflicts with the compiler-provided declarations under the current Vue and TypeScript versions resolved by AccxUI main.

## Why this layer

All remaining diagnostics point to shared components in `hotwax/accxui`. The downstream app-owned macro imports were removed separately, after which the workflow reported only these three shared files. Fixing each consuming app would not address the shared compile contract.

## Verification

- GitHub `Verify build` run [#131](https://github.com/hotwax/accxui/actions/runs/29642292438) passed.
- `git diff --check` passed.
- Fresh `origin/main` inspection confirmed all three imports were still present and no existing issue, PR, or commit covered the fix.
- `pnpm exec vue-tsc --noEmit --ignoreDeprecations 6.0` proceeds past all four macro-conflict diagnostics; the root typecheck then stops on pre-existing `DateTime` typing errors in `common/utils/commonUtil.ts`.
- `pnpm run build` is independently blocked before compilation by existing TypeScript 6 deprecations for `moduleResolution=node10` and `baseUrl`.
- Focused ESLint reaches all three components; reported quote/spacing/template-style findings are pre-existing and outside this import-only fix.

## Risk

Low. The change removes compile-time-only imports for macros that remain available through Vue `<script setup>`; no runtime or UI behavior changes.
