### PR TITLE
Fixed: Login stuck issue on relogin after first failed attempt. Also displayed error message correctly (#109).

### DIFF
--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -118,13 +118,15 @@ export function useAuth() {
       }
 
       updateToken("", "")
-      accxuiConfig.value.oms = "",
       accxuiConfig.value.current = {}
 
-      commonUtil.showToast(translate("Something went wrong while login. Please contact administrator."));
+      // Moqui login returns a non-2xx status (e.g. bad credentials), so axios rejects
+      // before `hasError()` can inspect the body - surface that message here instead.
+      const loginErrorMessage = err?.response?.data?.errors;
+      commonUtil.showToast(loginErrorMessage ? translate(loginErrorMessage) : translate("Something went wrong while login. Please contact administrator."));
       logger.error("error: ", err.toString());
 
-      return Promise.reject(err instanceof Object ? err : new Error(err));
+      return Promise.reject(loginErrorMessage ? new Error(loginErrorMessage) : (err instanceof Object ? err : new Error(err)));
     }
   }
 


### PR DESCRIPTION


### Related Issues
#109 
#

### Short Description and Why It's Useful
The OMS is cleared from the ACCXUI configuration after the first failed login attempt. This leads to a mismatch between the OMS value in the cookie and the ACCXUI configuration, as the OMS cookie is never cleared after a failed login. By not resetting the accxui config on failed login will fix this problem.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [ ] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/accxui#contribution-guideline)