### PR TITLE
Implemented: function to check for whether the current moqui version matches the required version for specific feature to run

### DIFF
--- a/common/utils/commonUtil.spec.ts
+++ b/common/utils/commonUtil.spec.ts
@@ -36,3 +36,70 @@ describe("commonUtil local instance URLs", () => {
     expect(commonUtil.getOmsURL()).toBe("https://demo.hotwax.io/rest/s1/");
   });
 });
+
+describe("commonUtil.isValidVersion", () => {
+  it("accepts well-formed semantic versions", () => {
+    expect(commonUtil.isValidVersion("1.0.0")).toBe(true);
+    expect(commonUtil.isValidVersion("0.1.0")).toBe(true);
+    expect(commonUtil.isValidVersion("10.20.30")).toBe(true);
+    expect(commonUtil.isValidVersion(" 2.3.4 ")).toBe(true); // trims surrounding whitespace
+    expect(commonUtil.isValidVersion("v1.0.0")).toBe(true); // optional v prefix
+    expect(commonUtil.isValidVersion("V2.3.4")).toBe(true); // optional uppercase V prefix
+    expect(commonUtil.isValidVersion("1.0.0-alpha.1")).toBe(true); // prerelease
+    expect(commonUtil.isValidVersion("1.0.0+build.5")).toBe(true); // build metadata
+    expect(commonUtil.isValidVersion("v1.2.3-rc.1+build.5")).toBe(true); // prefix + prerelease + build
+  });
+
+  it("rejects malformed or non-string values", () => {
+    expect(commonUtil.isValidVersion("1.0")).toBe(false);
+    expect(commonUtil.isValidVersion("version1.0.0")).toBe(false);
+    expect(commonUtil.isValidVersion("vv1.0.0")).toBe(false);
+    expect(commonUtil.isValidVersion("1.0.0.0")).toBe(false);
+    expect(commonUtil.isValidVersion("01.0.0")).toBe(false); // no leading zeros
+    expect(commonUtil.isValidVersion("1.0.x")).toBe(false);
+    expect(commonUtil.isValidVersion("")).toBe(false);
+    expect(commonUtil.isValidVersion(100 as any)).toBe(false);
+    expect(commonUtil.isValidVersion(null as any)).toBe(false);
+  });
+});
+
+describe("commonUtil.isVersionGreaterOrEqual", () => {
+  it("returns true when the second version is greater than the first", () => {
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "1.0.1")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "1.1.0")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("1.9.0", "2.0.0")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("2.3.9", "2.3.10")).toBe(true); // numeric, not lexical
+  });
+
+  it("returns true when the versions are equal", () => {
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "1.0.0")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("2.3.4", "2.3.4")).toBe(true);
+  });
+
+  it("returns false when the second version is lower", () => {
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.1", "1.0.0")).toBe(false);
+    expect(commonUtil.isVersionGreaterOrEqual("2.0.0", "1.9.9")).toBe(false);
+    expect(commonUtil.isVersionGreaterOrEqual("1.1.0", "1.0.9")).toBe(false);
+  });
+
+  it("handles the optional v/V prefix on either argument", () => {
+    expect(commonUtil.isVersionGreaterOrEqual("v1.0.0", "v1.0.1")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "v1.0.1")).toBe(true); // mixed prefix
+    expect(commonUtil.isVersionGreaterOrEqual("V1.2.0", "1.2.0")).toBe(true); // equal ignoring prefix
+  });
+
+  it("strips prerelease/build metadata before comparing core versions", () => {
+    // "1.0.1-rc1" must not leave "1-rc1" as the patch (which would be NaN)
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "1.0.1-rc1")).toBe(true);
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.1-rc1", "1.0.0")).toBe(false);
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0-alpha", "1.0.0")).toBe(true); // core equal → true
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "1.0.0-rc.1")).toBe(true); // core equal → true
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0+build.1", "1.0.0+build.9")).toBe(true); // build ignored, equal
+  });
+
+  it("returns false when either argument is not a valid version", () => {
+    expect(commonUtil.isVersionGreaterOrEqual("1.0", "1.0.1")).toBe(false);
+    expect(commonUtil.isVersionGreaterOrEqual("1.0.0", "not-a-version")).toBe(false);
+    expect(commonUtil.isVersionGreaterOrEqual(undefined as any, "1.0.0")).toBe(false);
+  });
+});

--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -601,6 +601,27 @@ const isValidPassword = (password: string) => {
   return passwordPattern.test(password);
 }
 
+// Matches semver with optional -prerelease and +build metadata,
+// plus an optional leading "v"/"V" prefix (e.g. "v1.2.3-rc.1+build.5").
+const SEMANTIC_VERSION_PATTERN = /^[vV]?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+// Checks whether the passed value is a valid semver string.
+const isValidVersion = (value: any): boolean => {
+  return typeof value === "string" && SEMANTIC_VERSION_PATTERN.test(value.trim());
+}
+
+// Checks whether currentVersion is greater than or equal to the requiredVersion,
+// Any -prerelease / +build metadata is stripped and ignored, so 1.0.0 and 1.0.0-rc.1 compare as equal.
+const isVersionGreaterOrEqual = (requiredVersion: string, currentVersion: string): boolean => {
+  if (!isValidVersion(requiredVersion) || !isValidVersion(currentVersion)) return false;
+  const parse = (version: string) => version.trim().replace(/^[vV]/, "").split(/[-+]/)[0].split(".").map(Number);
+  const [requiredMajor, requiredMinor, requiredPatch] = parse(requiredVersion);
+  const [currentMajor, currentMinor, currentPatch] = parse(currentVersion);
+  if (currentMajor !== requiredMajor) return currentMajor > requiredMajor;
+  if (currentMinor !== requiredMinor) return currentMinor > requiredMinor;
+  return currentPatch >= requiredPatch;
+}
+
 const isValidDeliveryDays = (deliveryDays: any) => {
   // Regular expression pattern for a valid delivery days
   // Allow only positive integers (no decimals, no zero, no negative)
@@ -987,6 +1008,8 @@ export const commonUtil = {
   isValidDeliveryDays,
   isValidEmail,
   isValidPassword,
+  isValidVersion,
+  isVersionGreaterOrEqual,
   jsonParse,
   jsonToCsv,
   parseBooleanSetting,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have requirement for checking for backend version before enabling specific feature in apps, so defined a common function that tells whether the current version is greater than or equal to required or not.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/accxui#contribution-guideline)