### PR TITLE
Preserve Solr facets in wrapped Moqui responses

### DIFF
--- a/common/composables/useSolrSearch.spec.ts
+++ b/common/composables/useSolrSearch.spec.ts
@@ -1,14 +1,29 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import api from '../core/remoteApi';
 import { useSolrSearch } from './useSolrSearch';
 
-const { prepareOrderLookupQuery } = useSolrSearch();
+vi.mock('../core/remoteApi', () => ({
+  default: vi.fn()
+}));
+
+vi.mock('../utils/commonUtil', () => ({
+  commonUtil: {
+    isMoqui: vi.fn(() => true)
+  }
+}));
+
+const { prepareOrderLookupQuery, runSolrQuery } = useSolrSearch();
+
+beforeEach(() => {
+  vi.mocked(api).mockReset();
+});
 
 describe('prepareOrderLookupQuery', () => {
   it('should have default filters and params', () => {
     const query = {};
     const payload = prepareOrderLookupQuery(query);
     expect(payload.json.filter).toEqual(["docType: ORDER", "orderTypeId: SALES_ORDER"]);
-    expect(payload.json.params.q.op).toBe("AND");
+    expect(payload.json.params["q.op"]).toBe("AND");
     expect(payload.json.query).toBe("*:*");
   });
 
@@ -69,5 +84,100 @@ describe('prepareOrderLookupQuery', () => {
     const query3 = { date: 'custom', fromDate: '2023-01-01T12:00:00Z' };
     const payload3 = prepareOrderLookupQuery(query3);
     expect(payload3.json.filter).toContain('{!tag=orderLookupFilter}orderDate: [2023-01-01T00:00:00Z TO *]');
+  });
+});
+
+describe('runSolrQuery', () => {
+  const payload = {
+    json: {
+      query: '*:*'
+    }
+  };
+
+  it('preserves facets when normalizing a wrapped document response', async () => {
+    const responseHeader = { status: 0, QTime: 1 };
+    const response = { numFound: 1, start: 0, docs: [{ orderId: '10000' }] };
+    const facets = {
+      count: 1,
+      facilityIdFacet: {
+        buckets: [{ val: '_NA_', count: 1 }]
+      }
+    };
+    vi.mocked(api).mockResolvedValue({
+      data: {
+        response: {
+          responseHeader,
+          response,
+          facets
+        }
+      }
+    });
+
+    const result = await runSolrQuery(payload);
+
+    expect(api).toHaveBeenCalledWith({
+      url: 'admin/search/query',
+      method: 'post',
+      data: payload.json
+    });
+    expect(result.data.responseHeader).toBe(responseHeader);
+    expect(result.data.response).toBe(response);
+    expect(result.data.facets).toBe(facets);
+  });
+
+  it('preserves facets when normalizing a wrapped grouped response', async () => {
+    const responseHeader = { status: 0, QTime: 1 };
+    const grouped = {
+      orderId: {
+        matches: 1,
+        ngroups: 1,
+        groups: []
+      }
+    };
+    const facets = {
+      count: 1,
+      statusIdFacet: {
+        buckets: [{ val: 'ORDER_APPROVED', count: 1 }]
+      }
+    };
+    vi.mocked(api).mockResolvedValue({
+      data: {
+        response: {
+          responseHeader,
+          grouped,
+          facets
+        }
+      }
+    });
+
+    const result = await runSolrQuery(payload);
+
+    expect(result.data.responseHeader).toBe(responseHeader);
+    expect(result.data.grouped).toBe(grouped);
+    expect(result.data.facets).toBe(facets);
+    expect(result.data).not.toHaveProperty('response');
+  });
+
+  it('leaves an already-flat response unchanged', async () => {
+    const response = {
+      data: {
+        responseHeader: { status: 0, QTime: 1 },
+        response: {
+          numFound: 1,
+          start: 0,
+          docs: [{ orderId: '10000' }]
+        },
+        facets: {
+          count: 1
+        }
+      }
+    };
+    const original = structuredClone(response);
+    vi.mocked(api).mockResolvedValue(response);
+
+    const result = await runSolrQuery(payload);
+
+    expect(result).toBe(response);
+    expect(result).toEqual(original);
   });
 });

--- a/common/composables/useSolrSearch.ts
+++ b/common/composables/useSolrSearch.ts
@@ -276,6 +276,9 @@ function normalizeSearchResponse(resp: any): any {
   const inner = resp?.data?.response;
   if (inner?.responseHeader) {
     resp.data.responseHeader = inner.responseHeader;
+    if (Object.prototype.hasOwnProperty.call(inner, "facets")) {
+      resp.data.facets = inner.facets;
+    }
     if (inner.response) {
       resp.data.response = inner.response;
     } else if (inner.grouped) {
@@ -411,4 +414,4 @@ export function useSolrSearch() {
     runSolrQuery,
     searchProducts
   }
-} 
+}


### PR DESCRIPTION
## Business summary

Order Manager's Funnel uses Solr facets for queue totals and physical-facility fallback rows. Moqui was returning valid facet buckets, but the shared AccxUI response adapter discarded that part of the envelope, causing downstream applications to render false zero or empty states.

This PR restores the shared response contract so every AccxUI consumer receives the facet data already returned by Solr.

Closes #119
Supports hotwax/order-manager#336 and hotwax/order-manager#329.

## Root cause

`normalizeSearchResponse` normalized wrapped `response` and `grouped` payloads but did not copy the sibling `facets` object into `resp.data`. Application code correctly looked for `data.facets`, so valid buckets visible in the Network response disappeared before reaching Order Manager.

## What changed

- Preserve `inner.facets` on the normalized response data.
- Cover wrapped document, wrapped grouped, and unchanged flat response shapes.
- Keep application-specific Funnel logic out of the shared layer.

## Validation

- `pnpm exec vitest run common/composables/useSolrSearch.spec.ts` — 9 tests passed.
- AccxUI + cumulative Order Manager production build — passed (1,076 modules transformed).
- Adversarial review found no actionable shared-layer finding.
- `git diff --check` — passed.

The broader common utility suite still has three pre-existing localhost cookie/environment failures unrelated to this diff.

## Evidence and rollout risk

The defect was reproducible from the raw Moqui response envelope, so a Jam recording is waived in favor of the exact response-contract tests. End-to-end Funnel acceptance remains on the dependent Order Manager stack against a reachable real OMS instance; this PR does not change Solr queries or count semantics.