### PR TITLE
Give shared Sparkline SVGs accessible names

### DIFF
--- a/common/components/Sparkline.spec.ts
+++ b/common/components/Sparkline.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import Sparkline from './Sparkline.vue';
+
+describe('Sparkline accessibility', () => {
+  it('exposes a labeled SVG as an image with the supplied accessible name', () => {
+    const wrapper = mount(Sparkline, {
+      props: {
+        points: [2, 6, 4],
+        ariaLabel: 'Unfillable orders over the last seven days'
+      }
+    });
+
+    const sparkline = wrapper.get('svg');
+    expect(sparkline.attributes('role')).toBe('img');
+    expect(sparkline.attributes('aria-label')).toBe('Unfillable orders over the last seven days');
+    expect(sparkline.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('hides an unlabeled SVG from assistive technology', () => {
+    const wrapper = mount(Sparkline, {
+      props: {
+        points: [2, 6, 4]
+      }
+    });
+
+    const sparkline = wrapper.get('svg');
+    expect(sparkline.attributes('aria-hidden')).toBe('true');
+    expect(sparkline.attributes('role')).toBeUndefined();
+    expect(sparkline.attributes('aria-label')).toBeUndefined();
+  });
+
+  it('preserves the normalized polyline geometry for varying values', () => {
+    const wrapper = mount(Sparkline, {
+      props: {
+        points: [2, 6, 4],
+        ariaLabel: 'Trend'
+      }
+    });
+
+    expect(wrapper.get('polyline').attributes('points')).toBe('0,28 50,2 100,15');
+  });
+});

--- a/common/components/Sparkline.vue
+++ b/common/components/Sparkline.vue
@@ -9,6 +9,9 @@
       :viewBox="`0 0 100 ${height}`"
       width="100%"
       :height="height"
+      :role="ariaLabel ? 'img' : undefined"
+      :aria-label="ariaLabel || undefined"
+      :aria-hidden="ariaLabel ? undefined : 'true'"
       :stroke="`var(--ion-color-${color})`"
       :stroke-width="strokeWidth"
       fill="none"
@@ -40,6 +43,12 @@ const props = defineProps({
   height: {
     type: Number,
     default: 30
+  },
+  // Names informative trends at the SVG itself. Unnamed instances are treated
+  // as decorative so they do not expose an anonymous image to assistive tech.
+  ariaLabel: {
+    type: String,
+    default: ''
   }
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [vue()]
+});


### PR DESCRIPTION
## Business summary

Inline trends communicate operational movement at a glance, but the shared Sparkline currently leaves the actual SVG unnamed for assistive technology. This change makes informative trends programmatically identifiable and explicitly hides unlabeled decorative instances, without changing their geometry or appearance.

Closes #121
Depends on #120

## What changed

- Declares the caller-compatible optional `ariaLabel` prop, consuming kebab-case `aria-label` instead of letting it fall through to the wrapper.
- Applies `role="img"` and the exact accessible name directly to labeled SVGs.
- Applies `aria-hidden="true"` to unlabeled SVGs without exposing an unnamed image role.
- Leaves viewBox, dimensions, stroke, polyline normalization, layout, and styling unchanged.
- Adds colocated shared-component regression coverage and a Vitest-only Vue SFC transform for the root common test suite.

## Validation

- Colocated AccxUI suite: `pnpm test:unit --run common/components/Sparkline.spec.ts` — 3 tests passed.
  - Labeled SVG owns the image role and exact supplied name.
  - Unlabeled SVG is hidden and has no role/name.
  - A varying fixture retains the exact normalized polyline geometry.
- Linked rendered Order Manager integration suite: 3 Sparkline tests passed.
  - Labeled SVG owns the role and exact name; wrapper is unnamed.
  - Unlabeled SVG is hidden and has no image role/name.
  - A varying 24-point nonzero fixture remains a non-flat polyline.
- Order Manager production build using this shared-component head: passed; 1,078 modules transformed.
- `git diff --check`: passed.
- Independent adversarial review found no actionable issues.
- Broader common smoke was not fully green: the new Sparkline suite and 9 Solr tests passed, while 3 pre-existing `commonUtil` localhost URL assertions outside this diff failed.

## Stack

- Position: **2 of 2** in the AccxUI prerequisite stack.
- Base PR: #120
- Base branch: `codex/funnel-solr-facet-envelope`
- Head branch: `codex/funnel-sparkline-accessibility`

## Remaining live gate

A desktop accessibility-tree/screen-reader smoke remains pending; the rendered DOM contract is covered by the colocated and linked component tests. No production state was changed.
