### PR TITLE
Fixed: solr resp normalized function to return facets response

### DIFF
--- a/common/composables/useSolrSearch.ts
+++ b/common/composables/useSolrSearch.ts
@@ -276,6 +276,9 @@ function normalizeSearchResponse(resp: any): any {
   const inner = resp?.data?.response;
   if (inner?.responseHeader) {
     resp.data.responseHeader = inner.responseHeader;
+    if (inner?.facets) {
+      resp.data.facets = inner.facets;
+    }
     if (inner.response) {
       resp.data.response = inner.response;
     } else if (inner.grouped) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In most cases we fetch facets from solr, but the normalizeSearchResponse function does not honor facets and return response without facets data.
Added check to include the facets data in solr response while normalizing.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/accxui#contribution-guideline)