### PR TITLE
Improved: version util to consider the oms version as valid if the passed value is not a semver

### DIFF
--- a/common/utils/commonUtil.ts
+++ b/common/utils/commonUtil.ts
@@ -613,7 +613,9 @@ const isValidVersion = (value: any): boolean => {
 // Checks whether currentVersion is greater than or equal to the requiredVersion,
 // Any -prerelease / +build metadata is stripped and ignored, so 1.0.0 and 1.0.0-rc.1 compare as equal.
 const isVersionGreaterOrEqual = (requiredVersion: string, currentVersion: string): boolean => {
-  if (!isValidVersion(requiredVersion) || !isValidVersion(currentVersion)) return false;
+  // If no compatibility requirement is configured or current version is not available or invalid
+  // (assuming that the server is on some branch), allow access by default
+  if (!isValidVersion(requiredVersion) || !isValidVersion(currentVersion)) return true;
   const parse = (version: string) => version.trim().replace(/^[vV]/, "").split(/[-+]/)[0].split(".").map(Number);
   const [requiredMajor, requiredMinor, requiredPatch] = parse(requiredVersion);
   const [currentMajor, currentMinor, currentPatch] = parse(currentVersion);


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As instances can be on custom branches, thus will not match a valid semver check, so assuming that if a version is not a valid semver then the instance is on some branch and thus all the latest changes are available on the branch

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Is the changes contains any breaking change?
If there are any breaking change include those in the release notes file

- [ ] Yes
- [x] No


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/accxui#contribution-guideline)