### PR TITLE
Fix: Restrict product search results to sellable variants (#449)

### DIFF
--- a/common/composables/useSolrSearch.ts
+++ b/common/composables/useSolrSearch.ts
@@ -373,6 +373,10 @@ async function searchProducts(params: { keyword?: string, sort?: string, qf?: st
     payload.json.filter += ` ${OPERATOR.AND} isVirtual: false`
   }
 
+  if (!params.filters?.isVariant) {
+    payload.json.filter += ` ${OPERATOR.AND} isVariant: true`
+  }
+
   try {
     const isMoqui = commonUtil.isMoqui();
     let resp = await api({


### PR DESCRIPTION
## Summary

Fixes [#449](https://github.com/hotwax/order-manager/issues/449) , [#260](https://github.com/hotwax/transfers/issues/260) by updating the shared product search implementation in `common/composables/useSolrSearch.ts` to automatically include `isVariant: true` for product searches.

Previously, product searches only filtered out virtual products (`isVirtual: false`), allowing non-sellable products (such as service products, templates, or parent products) to appear in search results.

By adding `isVariant: true` as a default filter, all product search workflows now return only sellable product variants while preserving existing behavior for callers that explicitly specify an `isVariant` filter.

## Changes

### Shared Product Search (`common/composables/useSolrSearch.ts`)

Updated the default filter construction in `searchProducts()`:

```ts
if (!params.filters?.isVirtual) {
  payload.json.filter += ` ${OPERATOR.AND} isVirtual: false`;
}

if (!params.filters?.isVariant) {
  payload.json.filter += ` ${OPERATOR.AND} isVariant: true`;
}