### PR TITLE
fix: ensure Solr requests include top-level json.query

### DIFF
--- a/common/composables/useSolrSearch.ts
+++ b/common/composables/useSolrSearch.ts
@@ -291,6 +291,7 @@ function normalizeSearchResponse(resp: any): any {
 
 async function runSolrQuery(payload: any): Promise<any> {
   const isMoqui = commonUtil.isMoqui();
+  if (payload.json && !payload.json.query) payload.json.query = payload.json.params?.q || "*:*";
   const resp = await api({
     url: isMoqui ? "admin/search/query" : "admin/runSolrQuery",
     method: "post",


### PR DESCRIPTION
## Summary

Fixes Solr search requests that fail with a `400 Bad Request` when the top-level `json.query` field is omitted from the request payload.

The shared Solr request builder previously relied on `params.q` but did not guarantee that `json.query` was present. Some backend endpoints require this field and reject requests when it is missing.

This change updates the shared implementation so that `json.query` is automatically populated when absent.

---

## Changes

### Shared Solr Search (`common/composables/useSolrSearch.ts`)

Added a safeguard before dispatching Solr requests:

```ts
if (payload.json && !payload.json.query) {
  payload.json.query = payload.json.params?.q || "*:*";
}
```

This ensures all Solr requests include the required top-level `json.query` field while preserving existing behavior for callers that already specify it.

---

## Request Payload

### Before

```json
{
  "json": {
    "params": {
      "rows": 50,
      "start": 0,
      "q": "*:*"
    },
    "filter": [
      "docType: ORDER"
    ]
  }
}
```

Result:

```
400 Bad Request

The json parameter with a query is required
```

---

### After

```json
{
  "json": {
    "query": "*:*",
    "params": {
      "rows": 50,
      "start": 0,
      "q": "*:*"
    },
    "filter": [
      "docType: ORDER"
    ]
  }
}
```

Result:

```
200 OK
```

---

## Verification

- Verified Solr request payloads include the top-level `json.query` field.
- Verified previously failing requests execute successfully.
- Verified existing Solr search behavior remains unchanged for callers that already provide `json.query`.

Fixes [#450](https://github.com/hotwax/order-manager/issues/450)