### PR TITLE
feat(login): dev servers list with auto-login badge, explicit dev login on credentials form, and setup guide

### DIFF
--- a/common/components/DxpShopifyImg.vue
+++ b/common/components/DxpShopifyImg.vue
@@ -1,5 +1,5 @@
 <template>
-  <img :src="imageUrl">
+  <img :src="imageUrl" />
 </template>
 
 <script setup lang="ts">

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -70,6 +70,22 @@
               </ion-chip>
             </div>
 
+            <ion-item
+              v-if="canDevAutoLoginForCurrentOms"
+              button
+              lines="full"
+              :disabled="isLoggingIn"
+              @click="attemptDevAutoLogin(true)"
+            >
+              <ion-label>
+                {{ configuredDevUsername }}
+                <p>{{ translate("Configured dev user") }}</p>
+              </ion-label>
+              <ion-badge color="primary" slot="end">
+                {{ translate("Auto login") }}
+              </ion-badge>
+            </ion-item>
+
             <ion-item lines="full">
               <ion-input :label="translate('Username')" label-placement="fixed" name="username" v-model="username" id="username"  type="text" required />
             </ion-item>
@@ -83,6 +99,18 @@
                 <ion-spinner v-if="isLoggingIn" slot="end" name="crescent" />
                 <ion-icon v-else slot="end" :icon="arrowForwardOutline" />
               </ion-button>
+            </div>
+
+            <div v-if="canShowAutoLoginDocLink" class="ion-text-center ion-padding-bottom">
+              <ion-note>
+                <a
+                  href="https://github.com/hotwax/accxui/blob/main/docs/DEV_AUTO_LOGIN.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ translate("How to configure auto login") }}
+                </a>
+              </ion-note>
             </div>
           </section>
         </form>
@@ -193,6 +221,41 @@ const canDevAutoLogin = () => {
   return Boolean(import.meta.env.DEV && devUsername && devPassword);
 };
 
+const normalizeOmsUrl = (url: string) => url.trim().toLowerCase().replace(/\/+$/, "");
+
+const configuredDevUsername = computed(() => getDevCredentials().devUsername || "");
+
+const canDevAutoLoginForCurrentOms = computed(() => {
+  if (!canDevAutoLogin()) return false;
+  const currentOms = (cookieHelper().get("oms") || instanceUrl.value || accxuiConfig.value?.oms || "").toString().trim().toLowerCase();
+  if (!currentOms) return false;
+
+  const normalizedCurrentOms = normalizeOmsUrl(currentOms);
+  const resolvedCurrentOms = normalizeOmsUrl(alias[currentOms] ? alias[currentOms] : currentOms);
+
+  if (defaultAlias) {
+    const rawDefault = defaultAlias.trim().toLowerCase();
+    const normalizedDefault = normalizeOmsUrl(rawDefault);
+    const resolvedDefault = normalizeOmsUrl(alias[rawDefault] ? alias[rawDefault] : rawDefault);
+
+    if (
+      [normalizedDefault, resolvedDefault].includes(normalizedCurrentOms) ||
+      [normalizedDefault, resolvedDefault].includes(resolvedCurrentOms)
+    ) {
+      return true;
+    }
+  }
+
+  return (
+    normalizedCurrentOms.includes("localhost") ||
+    normalizedCurrentOms.includes("127.0.0.1") ||
+    resolvedCurrentOms.includes("localhost") ||
+    resolvedCurrentOms.includes("127.0.0.1")
+  );
+});
+
+const canShowAutoLoginDocLink = computed(() => Boolean(import.meta.env.DEV && !canDevAutoLoginForCurrentOms.value));
+
 // A BASIC OMS is the only one we can sign into with a username and password. An empty
 // loginOption means it has not been fetched for this OMS yet, and setOms fetches it before
 // deciding, so treating that as BASIC here defers the decision rather than guessing.
@@ -293,8 +356,6 @@ export interface DevServer {
   signal?: LocalApiServerSignal;
   isEnv?: boolean;
 }
-
-const normalizeOmsUrl = (url: string) => url.trim().toLowerCase().replace(/\/+$/, "");
 
 const devServers = computed<DevServer[]>(() => {
   if (!canDiscoverLocalApiServers()) return [];
@@ -438,20 +499,6 @@ const initialise = async () => {
 
     if (showOmsInput.value) {
       discoverLocalApiServerOptions();
-
-      // VITE_DEFAULT_ALIAS only prefills the OMS input, it never applies it, so dev auto-login
-      // had no resolved instance to authenticate against and the developer was dropped on an
-      // empty form. Apply the prefilled OMS the same way selecting a discovered server does.
-      if(canDevAutoLogin() && instanceUrl.value && isBasicLoginOption()) {
-        await setOms();
-      }
-    }
-
-    // setOms clears showOmsInput for a BASIC OMS and redirects away for a SAML one, so reaching
-    // here with the credentials form showing means signing in is both possible and safe. This
-    // also covers a reload where the OMS is already set and only the credentials are missing.
-    if(!showOmsInput.value) {
-      await attemptDevAutoLogin();
     }
   } catch (error) {
     console.error(error);

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -138,6 +138,7 @@ const isLoggingIn = ref(false);
 const isDiscoveringLocalApiServers = ref(false);
 const localApiServers = ref<LocalApiServer[]>([]);
 const hasDiscoveredLocalApiServers = ref(false);
+const hasAttemptedDevAutoLogin = ref(false);
 let router: any = ref();
 
 const goToLogin = () => {
@@ -175,6 +176,35 @@ const toggleOmsInput = () => {
 
 const canDiscoverLocalApiServers = () => {
   return import.meta.env.DEV && typeof window !== "undefined";
+};
+
+const canDevAutoLogin = () => {
+  return Boolean(import.meta.env.DEV && import.meta.env.VITE_USERNAME && import.meta.env.VITE_PASSWORD);
+};
+
+// A BASIC OMS is the only one we can sign into with a username and password. An empty
+// loginOption means it has not been fetched for this OMS yet, and setOms fetches it before
+// deciding, so treating that as BASIC here defers the decision rather than guessing.
+const isBasicLoginOption = () => {
+  return !Object.keys(loginOption.value).length || loginOption.value.loginAuthType === "BASIC";
+};
+
+// Dev-only convenience: sign in with the credentials the local env supplies instead of making
+// a developer retype them on every reload. Automatic callers get one attempt per page load, so
+// a rejected sign-in leaves the form usable instead of retrying on each re-entry of the view;
+// an explicit server selection passes force since that is a deliberate retry.
+const attemptDevAutoLogin = async (force = false) => {
+  if(!canDevAutoLogin() || isLoggingIn.value) {
+    return;
+  }
+  if(!force && hasAttemptedDevAutoLogin.value) {
+    return;
+  }
+
+  hasAttemptedDevAutoLogin.value = true;
+  username.value = import.meta.env.VITE_USERNAME;
+  password.value = import.meta.env.VITE_PASSWORD;
+  await login();
 };
 
 const discoverLocalApiServerOptions = async () => {
@@ -257,13 +287,7 @@ const selectLocalApiServer = async (server: LocalApiServer) => {
   // user can't perform any operation there
   toggleOmsInput();
 
-  const devUsername = import.meta.env.VITE_USERNAME;
-  const devPassword = import.meta.env.VITE_PASSWORD;
-  if (import.meta.env.DEV && devUsername && devPassword) {
-    username.value = devUsername;
-    password.value = devPassword;
-    await login();
-  }
+  await attemptDevAutoLogin(true);
 };
 
 const initialise = async () => {
@@ -337,6 +361,20 @@ const initialise = async () => {
 
     if (showOmsInput.value) {
       discoverLocalApiServerOptions();
+
+      // VITE_DEFAULT_ALIAS only prefills the OMS input, it never applies it, so dev auto-login
+      // had no resolved instance to authenticate against and the developer was dropped on an
+      // empty form. Apply the prefilled OMS the same way selecting a discovered server does.
+      if(canDevAutoLogin() && instanceUrl.value && isBasicLoginOption()) {
+        await setOms();
+      }
+    }
+
+    // setOms clears showOmsInput for a BASIC OMS and redirects away for a SAML one, so reaching
+    // here with the credentials form showing means signing in is both possible and safe. This
+    // also covers a reload where the OMS is already set and only the credentials are missing.
+    if(!showOmsInput.value) {
+      await attemptDevAutoLogin();
     }
   } catch (error) {
     console.error(error);

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -27,6 +27,16 @@
               <ion-input :label="translate('OMS')" label-placement="fixed" name="instanceUrl" v-model="instanceUrl" id="instanceUrl" type="text" required />
             </ion-item>
 
+            <div class="ion-padding">
+              <!-- @keyup.enter.stop to stop the form from submitting on enter press as keyup.enter is already bound
+              through the form above, causing both the form and the button to submit. -->
+              <ion-button color="primary" expand="block" @click.prevent="isCheckingOms ? '' : setOms()" @keyup.enter.stop>
+                {{ translate("Next") }}
+                <ion-spinner v-if="isCheckingOms" name="crescent" slot="end" />
+                <ion-icon v-else slot="end" :icon="arrowForwardOutline" />
+              </ion-button>
+            </div>
+
             <ion-list v-if="canDiscoverLocalApiServers() && (isDiscoveringLocalApiServers || devServers.length)">
               <ion-list-header>
                 <ion-label>{{ translate("Dev servers") }}</ion-label>
@@ -51,16 +61,6 @@
                 </ion-note>
               </ion-item>
             </ion-list>
-
-            <div class="ion-padding">
-              <!-- @keyup.enter.stop to stop the form from submitting on enter press as keyup.enter is already bound
-              through the form above, causing both the form and the button to submit. -->
-              <ion-button color="primary" expand="block" @click.prevent="isCheckingOms ? '' : setOms()" @keyup.enter.stop>
-                {{ translate("Next") }}
-                <ion-spinner v-if="isCheckingOms" name="crescent" slot="end" />
-                <ion-icon v-else slot="end" :icon="arrowForwardOutline" />
-              </ion-button>
-            </div>
           </section>
 
           <section v-else>
@@ -69,22 +69,6 @@
                 {{ cookieHelper().get("oms") }}
               </ion-chip>
             </div>
-
-            <ion-item
-              v-if="canDevAutoLoginForCurrentOms"
-              button
-              lines="full"
-              :disabled="isLoggingIn"
-              @click="attemptDevAutoLogin(true)"
-            >
-              <ion-label>
-                {{ configuredDevUsername }}
-                <p>{{ translate("Configured dev user") }}</p>
-              </ion-label>
-              <ion-badge color="primary" slot="end">
-                {{ translate("Auto login") }}
-              </ion-badge>
-            </ion-item>
 
             <ion-item lines="full">
               <ion-input :label="translate('Username')" label-placement="fixed" name="username" v-model="username" id="username"  type="text" required />
@@ -100,6 +84,22 @@
                 <ion-icon v-else slot="end" :icon="arrowForwardOutline" />
               </ion-button>
             </div>
+
+            <ion-list v-if="canDevAutoLoginForCurrentOms">
+              <ion-item
+                button
+                :disabled="isLoggingIn"
+                @click="attemptDevAutoLogin(true)"
+              >
+                <ion-label>
+                  {{ configuredDevUsername }}
+                  <p>{{ translate("Configured dev user") }}</p>
+                </ion-label>
+                <ion-badge color="primary" slot="end">
+                  {{ translate("Auto login") }}
+                </ion-badge>
+              </ion-item>
+            </ion-list>
 
             <div v-if="canShowAutoLoginDocLink" class="ion-text-center ion-padding-bottom">
               <ion-note>

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -27,23 +27,26 @@
               <ion-input :label="translate('OMS')" label-placement="fixed" name="instanceUrl" v-model="instanceUrl" id="instanceUrl" type="text" required />
             </ion-item>
 
-            <ion-list v-if="isDiscoveringLocalApiServers || localApiServers.length">
+            <ion-list v-if="canDiscoverLocalApiServers() && (isDiscoveringLocalApiServers || devServers.length)">
               <ion-list-header>
-                <ion-label>{{ translate("Local OMS") }}</ion-label>
+                <ion-label>{{ translate("Dev servers") }}</ion-label>
                 <ion-spinner v-if="isDiscoveringLocalApiServers" name="crescent" />
               </ion-list-header>
               <ion-item
-                v-for="server in localApiServers"
+                v-for="server in devServers"
                 :key="server.oms"
                 button
                 :disabled="isCheckingOms"
-                @click="selectLocalApiServer(server)"
+                @click="selectDevServer(server)"
               >
                 <ion-label>
                   {{ server.label }}
                   <p>{{ server.oms }}</p>
                 </ion-label>
-                <ion-note slot="end">
+                <ion-badge v-if="server.hasAutoLogin" color="primary" slot="end">
+                  {{ translate("Auto login") }}
+                </ion-badge>
+                <ion-note v-else-if="server.signal" slot="end">
                   {{ server.signal === "loginOptions" ? translate("Ready") : translate("Detected") }}
                 </ion-note>
               </ion-item>
@@ -90,6 +93,7 @@
 
 <script setup lang="ts">
 import {
+  IonBadge,
   IonButton,
   IonChip,
   IonContent,
@@ -105,7 +109,7 @@ import {
   loadingController,
   onIonViewWillEnter
 } from "@ionic/vue";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import Logo from "./Logo.vue";
 import { arrowBackOutline, arrowForwardOutline, warningOutline } from 'ionicons/icons'
 import { cookieHelper } from "../helpers/cookieHelper";
@@ -113,7 +117,7 @@ import { translate } from "../core/i18n"
 import { commonUtil } from "../utils/commonUtil";
 import { useAuth } from "../composables/useAuth";
 import { accxuiConfig } from "../core/configRegistry";
-import { discoverLocalApiServers, type LocalApiServer } from "../core/localApiServerDiscovery";
+import { discoverLocalApiServers, type LocalApiServer, type LocalApiServerSignal } from "../core/localApiServerDiscovery";
 
 let route = null as any;
 
@@ -138,7 +142,7 @@ const isLoggingIn = ref(false);
 const isDiscoveringLocalApiServers = ref(false);
 const localApiServers = ref<LocalApiServer[]>([]);
 const hasDiscoveredLocalApiServers = ref(false);
-const hasAttemptedDevAutoLogin = ref(false);
+const hasAttemptedDevAutoLogin = ref(typeof window !== "undefined" && window.sessionStorage?.getItem("skipDevAutoLogin") === "true");
 let router: any = ref();
 
 const goToLogin = () => {
@@ -282,7 +286,70 @@ const setOms = async () => {
   isCheckingOms.value = false;
 };
 
-const selectLocalApiServer = async (server: LocalApiServer) => {
+export interface DevServer {
+  label: string;
+  oms: string;
+  hasAutoLogin: boolean;
+  signal?: LocalApiServerSignal;
+  isEnv?: boolean;
+}
+
+const normalizeOmsUrl = (url: string) => url.trim().toLowerCase().replace(/\/+$/, "");
+
+const devServers = computed<DevServer[]>(() => {
+  if (!canDiscoverLocalApiServers()) return [];
+
+  const servers: DevServer[] = [];
+  const seenOms = new Set<string>();
+
+  // 1. Dev server from env (VITE_DEFAULT_ALIAS)
+  if (defaultAlias) {
+    const rawEnvOms = defaultAlias.trim();
+    const resolvedEnvOms = alias[rawEnvOms.toLowerCase()] ? alias[rawEnvOms.toLowerCase()] : rawEnvOms;
+    const normalizedEnvOms = normalizeOmsUrl(resolvedEnvOms);
+
+    let label = defaultAlias;
+    if (defaultAlias === resolvedEnvOms) {
+      const aliasKey = Object.keys(alias).find((key) => normalizeOmsUrl(alias[key]) === normalizedEnvOms);
+      label = aliasKey || defaultAlias;
+    }
+
+    servers.push({
+      label,
+      oms: resolvedEnvOms,
+      hasAutoLogin: canDevAutoLogin(),
+      isEnv: true
+    });
+    seenOms.add(normalizedEnvOms);
+  }
+
+  // 2. Discovered local API servers
+  for (const server of localApiServers.value) {
+    const normalizedServerOms = normalizeOmsUrl(server.oms);
+    if (seenOms.has(normalizedServerOms)) {
+      const existing = servers.find((s) => normalizeOmsUrl(s.oms) === normalizedServerOms);
+      if (existing) {
+        existing.signal = server.signal;
+        if (server.label && existing.label === defaultAlias) {
+          existing.label = server.label;
+        }
+      }
+    } else {
+      servers.push({
+        label: server.label,
+        oms: server.oms,
+        hasAutoLogin: canDevAutoLogin(),
+        signal: server.signal,
+        isEnv: false
+      });
+      seenOms.add(normalizedServerOms);
+    }
+  }
+
+  return servers;
+});
+
+const selectDevServer = async (server: DevServer) => {
   if (isCheckingOms.value) return;
 
   instanceUrl.value = server.oms;
@@ -295,7 +362,9 @@ const selectLocalApiServer = async (server: LocalApiServer) => {
   // user can't perform any operation there
   toggleOmsInput();
 
-  await attemptDevAutoLogin(true);
+  if (server.hasAutoLogin) {
+    await attemptDevAutoLogin(true);
+  }
 };
 
 const initialise = async () => {

--- a/common/components/Login.vue
+++ b/common/components/Login.vue
@@ -499,6 +499,13 @@ const initialise = async () => {
 
     if (showOmsInput.value) {
       discoverLocalApiServerOptions();
+
+      // VITE_DEFAULT_ALIAS only prefills the OMS input, it never applies it. If dev auto-login
+      // is configured and instanceUrl is set, advance to the credentials form so the user lands
+      // directly on the username/password screen with the one-click dev user item.
+      if(canDevAutoLogin() && instanceUrl.value && isBasicLoginOption()) {
+        await setOms();
+      }
     }
   } catch (error) {
     console.error(error);

--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -55,7 +55,6 @@ export function useAuth() {
     cookieHelper().remove("maarg");
     cookieHelper().remove("userId");
     updateToken("", "")
-    updateOMS("")
     updateUserId("")
   }
 

--- a/docs/DEV_AUTO_LOGIN.md
+++ b/docs/DEV_AUTO_LOGIN.md
@@ -1,0 +1,51 @@
+# Configuring Dev Auto-Login in AccxUI Apps
+
+This guide explains how to configure automatic development login for AccxUI applications, how the login page interacts with dev servers, and important limitations when switching between test instances.
+
+---
+
+## 1. Overview
+
+During local development, retyping credentials or repeatedly choosing an OMS instance slows down rapid iteration. AccxUI provides dev-only conveniences:
+
+1. **Dev Servers Picker**: In the OMS selection step, development servers (local processes running on ports like `8080`, as well as servers configured in your `.env`) are listed under **Dev servers**. Servers that have credentials configured are badged with **Auto login** and log you in with a single click.
+2. **One-Click Dev Login**: When navigating directly to the login page (or after logging out), if your configured dev credentials match the active OMS, you will see a dedicated quick-login item with your dev username. Clicking it signs you in immediately without retyping your password, while still allowing you to stay logged out or sign in as a different user.
+
+---
+
+## 2. Configuration (`.env`)
+
+To enable dev auto-login for an AccxUI app (such as `company`, `order-manager`, `transfers`, etc.), add the following variables to your local `.env` file in that app:
+
+```bash
+# OMS Instance Configuration
+VITE_DEFAULT_ALIAS="http://localhost:8080"
+VITE_ALIAS='{"local":"http://localhost:8080"}'
+
+# Dev Credentials
+# Supported variable names: VITE_DEV_USERNAME / VITE_DEV_PASSWORD
+# (Legacy VITE_USERNAME / VITE_PASSWORD are also supported)
+VITE_DEV_USERNAME="admin"
+VITE_DEV_PASSWORD="password"
+```
+
+### Supported Variables
+| Variable | Description |
+| --- | --- |
+| `VITE_DEFAULT_ALIAS` | The default OMS alias or URL prefilled on boot (e.g. `http://localhost:8080` or `local`). |
+| `VITE_ALIAS` | Optional JSON string mapping short alias names to OMS URLs. |
+| `VITE_DEV_USERNAME` | The dev username to use for auto-login (or `VITE_USERNAME`). |
+| `VITE_DEV_PASSWORD` | The dev password to use for auto-login (or `VITE_PASSWORD`). |
+
+---
+
+## 3. Important Limitation: Single-Server Credentials
+
+> [!WARNING]
+> **AccxUI currently supports saving dev credentials for only one server at a time in your `.env`.**
+
+If you frequently switch between multiple test environments (for example, a local Moqui backend at `http://localhost:8080` and a remote shared test instance like `https://dev-oms.hotwax.io`):
+
+1. **Credentials do not carry across different servers**: The credentials in `VITE_DEV_USERNAME` / `VITE_DEV_PASSWORD` are associated with your primary configured server (`VITE_DEFAULT_ALIAS` or localhost).
+2. **Why auto-login is disabled on other servers**: When you switch the active OMS to a different server, the login page will **not** display the Auto login item or automatically submit credentials. This fails closed to prevent sending local credentials to remote servers or vice versa.
+3. **Switching active dev servers**: If you want auto-login to work on another test instance, update `VITE_DEFAULT_ALIAS`, `VITE_DEV_USERNAME`, and `VITE_DEV_PASSWORD` in your `.env` to match that server and restart the Vite dev server.


### PR DESCRIPTION
## Problem & Motivation

1. **Dev auto-login bypassed user control & broke logout**: Automatically logging in on every page load/reload prevented users from ever logging out (logout immediately re-triggered auto-login).
2. **Logout was clearing the OMS cookie**: `clearAuth()` called `updateOMS("")`, wiping the user's selected OMS and dropping them back onto the OMS discovery picker instead of landing on the credentials form for their active instance (directly contradicting `useAuth.ts`'s documented policy: *"do not clear oms cookie, this causes an issue on relogin to the same instance without moving to the oms page"*).
3. **Inconsistent layout between steps**: On the OMS step, the dev server list was positioned below the input, while on the credentials step, the configured dev user was placed above the username and password fields.
4. **Missing dev user action on direct navigation**: If a user directly navigated to the login credentials screen (e.g. OMS already set or remembered), there was no quick way to sign in with configured dev credentials without retyping them, nor could they easily sign in as another user.
5. **No clarity when switching test instances**: AccxUI only supports saving dev credentials for a single server in `.env`. When switching between local and remote test instances (e.g. `localhost:8080` vs `dev-oms.hotwax.io`), developers had no explanation why auto-login wasn't working.

## Changes

- **Consistent UI layout (dev options below the form)**:
  - **OMS step**: The form comprises the OMS input and the `Next` button at the top. The **Dev servers** list is placed directly below the form.
  - **Credentials step**: The form comprises the OMS chip, Username and Password inputs, and the `Login` button at the top. The **Configured dev user** list item (with `Auto login` badge) is placed directly below the form.
  - Both screens now maintain identical structural symmetry: primary inputs and actions first, development conveniences below.

- **Preserve OMS across logout**:
  - Removed `updateOMS("")` from `clearAuth()` in `useAuth.ts` so the active tenant instance remains remembered across logouts and session expirations.
  - In `Login.vue`, if dev auto-login is configured and an `instanceUrl` is known on cold boot without cookies, it applies `setOms()` to advance directly to the credentials form.

- **Explicit dev user action on credentials form**:
  - Removed unconditional automated login execution on page load/reload/logout.
  - When the active OMS matches configured dev credentials, the `ion-item` below the form displays the dev username, `Configured dev user`, and an `Auto login` badge. Clicking it logs in immediately with a single click.
  - Editable username and password fields remain available to test other users or stay logged out.

- **Auto-login documentation & fallback link**:
  - Created `docs/DEV_AUTO_LOGIN.md` detailing how to configure dev auto-login and explaining the single-server credential limitation.
  - When the active OMS does not have auto-login configured (or credentials differ), a **"How to configure auto login"** link appears below the login button, pointing directly to the documentation.

## Verification

- `pnpm --filter company build`: succeeded cleanly in ~13s.
- Verified on live runtime (`http://localhost:8103` with Moqui on `http://localhost:8080`):
  - **Credentials step**: Form (Username + Password + Login button) appears on top, with `codex.aditya` item below the form.
  - **OMS step**: Form (OMS input + Next button) appears on top, with `Dev servers` list below the form.
  - **Logout behavior**: Clicking Logout in Settings lands directly on the credentials screen (`http://localhost:8103/login`), preserves the OMS, and displays the one-click dev user item below the form.
  - **One-click login**: Clicking the configured dev user item authenticates and navigates to `/product-store`.
  - Captured screenshots confirming both UI states.