### PR TITLE
feat(common): add a shared useProducts product master

### DIFF
--- a/common/composables/useAuth.ts
+++ b/common/composables/useAuth.ts
@@ -8,6 +8,7 @@ import { DateTime } from "luxon";
 import { computed, ref } from "vue";
 import emitter from "../core/emitter";
 import { accxuiConfig } from "../core/configRegistry";
+import { clearSessionScopedState } from "../core/sessionScope";
 import { getCanonicalPath } from "../utils/appVersionUtil";
 
 interface LoginOption {
@@ -198,6 +199,9 @@ export function useAuth() {
         logger.error("Error running postLogout hook", err);
       }
     }
+
+    // Shared composables in common hold module-level tenant data too; sweep them after the app's own hook.
+    clearSessionScopedState()
 
     // Reset oms in app's state, as we are clearing app's state on logout, but do not clear oms cookie
     // this causes an issue on relogin to the same instance without moving to the oms page

--- a/common/composables/useProducts.ts
+++ b/common/composables/useProducts.ts
@@ -1,5 +1,6 @@
 import { ref } from "vue";
 import logger from "../core/logger";
+import { onSessionCleared } from "../core/sessionScope";
 import { commonUtil } from "../utils/commonUtil";
 import { useSolrSearch } from "./useSolrSearch";
 
@@ -14,8 +15,8 @@ import { useSolrSearch } from "./useSolrSearch";
  * same field list) but not their durable Dexie cache: the requirement is names for the rows a screen has
  * open, which a Map keyed by productId satisfies.
  *
- * Module state survives an SPA logout. Apps that clear session state on logout should call `reset()`
- * from their own session-clearing hook so the next login cannot read the previous tenant's products.
+ * Module state survives an SPA logout, so the composable registers its own `reset()` with the common
+ * session scope; `useAuth().logout()` runs it. No consumer has to remember to.
  */
 
 export interface ProductIdentification {
@@ -143,12 +144,14 @@ async function resolve(productIds: Iterable<string>): Promise<void> {
   products.value = next;
 }
 
-/** Forget every resolved product and every in-flight id. For the app's logout hook. */
+/** Forget every resolved product and every in-flight id. Runs on logout via the common session scope. */
 function reset(): void {
   generation += 1;
   products.value = new Map();
   requested.clear();
 }
+
+onSessionCleared(reset);
 
 export function useProducts() {
   return { products, resolve, getByIds, reset };

--- a/common/composables/useProducts.ts
+++ b/common/composables/useProducts.ts
@@ -1,0 +1,147 @@
+import { ref } from "vue";
+import logger from "../core/logger";
+import { commonUtil } from "../utils/commonUtil";
+import { useSolrSearch } from "./useSolrSearch";
+
+/**
+ * Shared product master: rich product data from Solr, keyed by HotWax productId, resolved once per
+ * session and never refetched.
+ *
+ * Several ledgers an operator reads carry no product at all (a Shopify inventory adjustment names a
+ * remote target and a delta), so a screen showing those rows can only offer an id unless it resolves
+ * the product separately. This is that resolver, in one place instead of a copy per app. It keeps the
+ * Solr query shape of the per-app `useProductMaster` composables (`docType:PRODUCT`, batched ids, the
+ * same field list) but not their durable Dexie cache: the requirement is names for the rows a screen has
+ * open, which a Map keyed by productId satisfies.
+ *
+ * Module state survives an SPA logout. Apps that clear session state on logout should call `reset()`
+ * from their own session-clearing hook so the next login cannot read the previous tenant's products.
+ */
+
+export interface ProductIdentification {
+  type: string;
+  value: string;
+}
+
+export interface ResolvedProduct {
+  productId: string;
+  /**
+   * The variant's own name. For a sized product this is just the option value ("S", "L", "XS"), so it
+   * is a qualifier, never the label on its own.
+   */
+  productName: string;
+  /** The name a merchandiser recognises. This is the one to show. */
+  parentProductName: string;
+  sku: string;
+  internalName: string;
+  mainImageUrl: string;
+  goodIdentifications: ProductIdentification[];
+}
+
+const PRODUCT_FIELDS = "productId productName parentProductName internalName goodIdentifications mainImageUrl";
+/** Solr takes the whole id list in one filter clause, so this caps the clause rather than the fetch. */
+const BATCH_SIZE = 200;
+
+const products = ref(new Map<string, ResolvedProduct>());
+/** Ids already requested, so a re-render cannot queue the same product twice. */
+const requested = new Set<string>();
+
+/** Solr treats these as syntax, so an id containing one has to arrive escaped or the query fails. */
+function escapeSolrValue(value: string): string {
+  return String(value).replace(/([\\+\-!(){}[\]^"~*?:]|&&|\|\|)/g, "\\$1");
+}
+
+/** `goodIdentifications` arrives as "TYPE/value" strings, or already as objects on some catalogs. */
+function parseGoodIdentifications(raw: unknown): ProductIdentification[] {
+  if(!Array.isArray(raw)) {return [];}
+
+  return raw.map((identification: any) => {
+    if(typeof identification === "string") {
+      const slash = identification.indexOf("/");
+
+      return slash === -1
+        ? { type: "", value: identification.trim() }
+        : { type: identification.slice(0, slash).trim(), value: identification.slice(slash + 1).trim() };
+    }
+
+    return { type: String(identification?.type || "").trim(), value: String(identification?.value || "").trim() };
+  });
+}
+
+function mapDocToProduct(doc: any): ResolvedProduct {
+  const goodIdentifications = parseGoodIdentifications(doc?.goodIdentifications);
+
+  return {
+    productId: String(doc?.productId ?? ""),
+    productName: String(doc?.productName || ""),
+    parentProductName: String(doc?.parentProductName || ""),
+    sku: String(doc?.sku || goodIdentifications.find((identification) => identification.type === "SKU")?.value || ""),
+    internalName: String(doc?.internalName || ""),
+    mainImageUrl: String(doc?.mainImageUrl || ""),
+    goodIdentifications,
+  };
+}
+
+function buildProductQuery(productIds: string[]) {
+  return {
+    json: {
+      params: { rows: productIds.length, start: 0, "q.op": "AND", fl: PRODUCT_FIELDS },
+      query: "*:*",
+      filter: ["docType:PRODUCT", `productId:(${productIds.map(escapeSolrValue).join(" OR ")})`],
+    },
+  };
+}
+
+/**
+ * Fetch products from Solr in batches. Does not touch the shared map. Failure is not thrown: a screen
+ * that cannot reach Solr should still show its rows with the ids it already has.
+ */
+async function getByIds(productIds: Iterable<string>): Promise<ResolvedProduct[]> {
+  const ids = [...new Set([...productIds].map(String).filter(Boolean))];
+  const resolved: ResolvedProduct[] = [];
+  for(let index = 0; index < ids.length; index += BATCH_SIZE) {
+    const batch = ids.slice(index, index + BATCH_SIZE);
+    try {
+      const response: any = await useSolrSearch().runSolrQuery(buildProductQuery(batch));
+      if(commonUtil.hasError(response)) {
+        logger.error("Product [Solr] - Query returned an error", response?.data);
+        continue;
+      }
+      for(const doc of response?.data?.response?.docs ?? []) {
+        const product = mapDocToProduct(doc);
+        if(product.productId) {resolved.push(product);}
+      }
+    } catch (error) {
+      logger.error("Product [Solr] - Query failed", error);
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Resolve any ids not already known or in flight into the shared map. Safe to call on every render: it
+ * filters against `requested` first, so a stable set of rows produces exactly one Solr round trip.
+ */
+async function resolve(productIds: Iterable<string>): Promise<void> {
+  const pending = [...new Set([...productIds].map(String).filter(Boolean))]
+    .filter((productId) => !requested.has(productId));
+  if(!pending.length) {return;}
+  pending.forEach((productId) => requested.add(productId));
+
+  const fetched = await getByIds(pending);
+  if(!fetched.length) {return;}
+  const next = new Map(products.value);
+  for(const product of fetched) {next.set(product.productId, product);}
+  products.value = next;
+}
+
+/** Forget every resolved product and every in-flight id. For the app's logout hook. */
+function reset(): void {
+  products.value = new Map();
+  requested.clear();
+}
+
+export function useProducts() {
+  return { products, resolve, getByIds, reset };
+}

--- a/common/composables/useProducts.ts
+++ b/common/composables/useProducts.ts
@@ -45,6 +45,12 @@ const BATCH_SIZE = 200;
 const products = ref(new Map<string, ResolvedProduct>());
 /** Ids already requested, so a re-render cannot queue the same product twice. */
 const requested = new Set<string>();
+/**
+ * Bumped by `reset()`. A resolve that was already awaiting Solr when the session was cleared captures
+ * the generation first and drops its result if it moved, so a logout mid-request cannot repopulate the
+ * map with the previous tenant's products.
+ */
+let generation = 0;
 
 /** Solr treats these as syntax, so an id containing one has to arrive escaped or the query fails. */
 function escapeSolrValue(value: string): string {
@@ -128,9 +134,10 @@ async function resolve(productIds: Iterable<string>): Promise<void> {
     .filter((productId) => !requested.has(productId));
   if(!pending.length) {return;}
   pending.forEach((productId) => requested.add(productId));
+  const requestGeneration = generation;
 
   const fetched = await getByIds(pending);
-  if(!fetched.length) {return;}
+  if(requestGeneration !== generation || !fetched.length) {return;}
   const next = new Map(products.value);
   for(const product of fetched) {next.set(product.productId, product);}
   products.value = next;
@@ -138,6 +145,7 @@ async function resolve(productIds: Iterable<string>): Promise<void> {
 
 /** Forget every resolved product and every in-flight id. For the app's logout hook. */
 function reset(): void {
+  generation += 1;
   products.value = new Map();
   requested.clear();
 }

--- a/common/core/sessionScope.ts
+++ b/common/core/sessionScope.ts
@@ -1,0 +1,34 @@
+/**
+ * Session-scoped module state in `common` — the logout story for shared composables.
+ *
+ * Shared composables (the product master, for one) hold tenant data at module level, and an SPA logout
+ * unmounts nothing, so without a reset the next login on the same tab reads the previous tenant's data.
+ * A composable registers its reset here at module scope; `useAuth().logout()` runs every registered
+ * reset exactly once, after the app's own `postLogout` hook. That makes the guarantee a property of the
+ * composable rather than of whichever app view happened to import it.
+ *
+ * Apps keep their own registries for app-local state; this one is only for state that lives in `common`.
+ */
+
+type SessionReset = () => void;
+
+const resets = new Set<SessionReset>();
+
+/** Register a reset for module-level session state held in `common`. Returns an unregister. */
+export function onSessionCleared(reset: SessionReset): () => void {
+  resets.add(reset);
+
+  return () => resets.delete(reset);
+}
+
+/** Run every registered reset. Called from `useAuth().logout()`; safe to call more than once. */
+export function clearSessionScopedState(): void {
+  for(const reset of resets) {
+    try {
+      reset();
+    } catch (error) {
+      // One composable's failure must not leave the rest of the session dirty.
+      console.error("sessionScope reset failed", error);
+    }
+  }
+}

--- a/common/index.ts
+++ b/common/index.ts
@@ -12,6 +12,7 @@ import { getFastTravelApps, getFastTravelApp, buildAppUrl } from './utils/fastTr
 import emitter from './core/emitter'
 import { commonUtil } from './utils/commonUtil'
 import { useSolrSearch } from './composables/useSolrSearch'
+import { useProducts } from './composables/useProducts'
 import { useShopify } from './composables/useShopify'
 import logger from './core/logger'
 import { cookieHelper } from './helpers/cookieHelper'
@@ -54,6 +55,7 @@ export {
   buildAppUrl,
   moduleFederationUtil,
   useSolrSearch,
+  useProducts,
   useShopify,
   translate,
   useNotificationStore,

--- a/common/index.ts
+++ b/common/index.ts
@@ -26,6 +26,7 @@ import { firebaseMessaging } from './core/firebaseMessaging'
 import { useNotificationStore } from './store/notification'
 import { useEmbeddedAppStore } from './store/embeddedApp'
 import { initialiseConfig } from './core/configRegistry'
+import { onSessionCleared, clearSessionScopedState } from './core/sessionScope'
 import { useAuth } from './composables/useAuth'
 
 // ✅ These are pure types (erased during build)
@@ -41,6 +42,8 @@ export {
   i18n,
   imagePreview,
   initialiseConfig,
+  onSessionCleared,
+  clearSessionScopedState,
   logger,
   Login,
   RadioFacetGroup,

--- a/common/tests/sessionScope.spec.ts
+++ b/common/tests/sessionScope.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { clearSessionScopedState, onSessionCleared } from "../core/sessionScope";
+
+describe("common sessionScope", () => {
+  it("runs every registered reset once per sweep and keeps going past a failing one", () => {
+    const first = vi.fn();
+    const failing = vi.fn(() => { throw new Error("boom"); });
+    const last = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const unregister = [onSessionCleared(first), onSessionCleared(failing), onSessionCleared(last)];
+
+    clearSessionScopedState();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(last).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    unregister.forEach((off) => off());
+    consoleError.mockRestore();
+  });
+
+  it("stops calling a reset once it is unregistered", () => {
+    const reset = vi.fn();
+    const off = onSessionCleared(reset);
+    off();
+
+    clearSessionScopedState();
+
+    expect(reset).not.toHaveBeenCalled();
+  });
+});

--- a/common/tests/useProducts.spec.ts
+++ b/common/tests/useProducts.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runSolrQuery = vi.fn();
+
+vi.mock("../composables/useSolrSearch", () => ({
+  useSolrSearch: () => ({ runSolrQuery }),
+}));
+vi.mock("../core/logger", () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+vi.mock("../utils/commonUtil", () => ({
+  commonUtil: { hasError: (response: any) => Boolean(response?.data?.error) },
+}));
+
+import { useProducts } from "../composables/useProducts";
+
+const solrDoc = (productId: string, overrides: Record<string, unknown> = {}) => ({
+  productId,
+  productName: "S",
+  parentProductName: `Parent ${productId}`,
+  internalName: `INT-${productId}`,
+  goodIdentifications: [`SKU/SKU-${ productId}`, "UPC/0001"],
+  mainImageUrl: "",
+  ...overrides,
+});
+
+describe("useProducts (shared product master)", () => {
+  beforeEach(() => {
+    runSolrQuery.mockReset();
+    useProducts().reset();
+  });
+
+  it("resolves ids into the shared map with the merchandiser-facing fields", async () => {
+    runSolrQuery.mockResolvedValueOnce({ data: { response: { docs: [solrDoc("P1"), solrDoc("P2")] } } });
+
+    const { products, resolve } = useProducts();
+    await resolve(["P1", "P2", "", "P1"]);
+
+    expect(runSolrQuery).toHaveBeenCalledTimes(1);
+    const query = runSolrQuery.mock.calls[0][0];
+    expect(query.json.filter).toEqual(["docType:PRODUCT", "productId:(P1 OR P2)"]);
+    expect(products.value.get("P1")).toMatchObject({ parentProductName: "Parent P1", sku: "SKU-P1", productName: "S" });
+    expect(products.value.get("P1")?.goodIdentifications).toEqual([
+      { type: "SKU", value: "SKU-P1" },
+      { type: "UPC", value: "0001" },
+    ]);
+  });
+
+  it("never asks Solr twice for an id already requested", async () => {
+    runSolrQuery.mockResolvedValue({ data: { response: { docs: [solrDoc("P1")] } } });
+    const { resolve } = useProducts();
+
+    await resolve(["P1"]);
+    await resolve(["P1"]);
+
+    expect(runSolrQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("escapes Solr syntax in ids and batches large id lists", async () => {
+    runSolrQuery.mockResolvedValue({ data: { response: { docs: [] } } });
+    const { resolve } = useProducts();
+    const ids = Array.from({ length: 201 }, (_, index) => `ID-${index}`);
+
+    await resolve([...ids, "a:b"]);
+
+    expect(runSolrQuery).toHaveBeenCalledTimes(2);
+    const filters = runSolrQuery.mock.calls.map((call) => call[0].json.filter[1]).join(" ");
+    expect(filters).toContain("ID\\-0");
+    expect(filters).toContain("a\\:b");
+  });
+
+  it("leaves rows unresolved on a Solr error and does not throw", async () => {
+    runSolrQuery.mockResolvedValueOnce({ data: { error: "boom" } });
+    const { products, resolve } = useProducts();
+
+    await expect(resolve(["P9"])).resolves.toBeUndefined();
+    expect(products.value.has("P9")).toBe(false);
+  });
+
+  it("reset() forgets resolved products so the next session refetches", async () => {
+    runSolrQuery.mockResolvedValue({ data: { response: { docs: [solrDoc("P1")] } } });
+    const { products, resolve, reset } = useProducts();
+
+    await resolve(["P1"]);
+    expect(products.value.size).toBe(1);
+    reset();
+    expect(products.value.size).toBe(0);
+    await resolve(["P1"]);
+    expect(runSolrQuery).toHaveBeenCalledTimes(2);
+  });
+});

--- a/common/tests/useProducts.spec.ts
+++ b/common/tests/useProducts.spec.ts
@@ -88,4 +88,22 @@ describe("useProducts (shared product master)", () => {
     await resolve(["P1"]);
     expect(runSolrQuery).toHaveBeenCalledTimes(2);
   });
+  it("drops a resolution that was in flight when reset() ran, so a logout cannot repopulate the map", async () => {
+    let release: (value: unknown) => void = () => {};
+    runSolrQuery.mockReturnValueOnce(new Promise((resolve) => { release = resolve; }));
+    const { products, resolve, reset } = useProducts();
+
+    const inFlight = resolve(["P1"]);
+    reset();
+    release({ data: { response: { docs: [solrDoc("P1")] } } });
+    await inFlight;
+
+    expect(products.value.size).toBe(0);
+
+    // The next session asks again and gets its own answer.
+    runSolrQuery.mockResolvedValueOnce({ data: { response: { docs: [solrDoc("P1", { parentProductName: "Tenant B" })] } } });
+    await resolve(["P1"]);
+    expect(products.value.get("P1")?.parentProductName).toBe("Tenant B");
+    expect(runSolrQuery).toHaveBeenCalledTimes(2);
+  });
 });

--- a/common/tests/useProducts.spec.ts
+++ b/common/tests/useProducts.spec.ts
@@ -13,6 +13,7 @@ vi.mock("../utils/commonUtil", () => ({
 }));
 
 import { useProducts } from "../composables/useProducts";
+import { clearSessionScopedState } from "../core/sessionScope";
 
 const solrDoc = (productId: string, overrides: Record<string, unknown> = {}) => ({
   productId,
@@ -105,5 +106,16 @@ describe("useProducts (shared product master)", () => {
     await resolve(["P1"]);
     expect(products.value.get("P1")?.parentProductName).toBe("Tenant B");
     expect(runSolrQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers its reset with the common session scope, so logout clears it without app wiring", async () => {
+    runSolrQuery.mockResolvedValue({ data: { response: { docs: [solrDoc("P1")] } } });
+    const { products, resolve } = useProducts();
+    await resolve(["P1"]);
+    expect(products.value.size).toBe(1);
+
+    clearSessionScopedState();
+
+    expect(products.value.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds `useProducts()` to `common/composables` and exports it from the `@common` barrel: a shared product master that resolves HotWax productIds into merchandiser-facing fields from Solr.

Company, order-manager, inventory-count and order-routing each carry their own copy of this resolver (`useProductMaster.ts`) with the same `docType:PRODUCT` query, the same field list and the same 200-id batching. This is the shared version. It deliberately keeps only an in-memory Map keyed by productId rather than the per-app Dexie caches; the first consumer needs names for the rows a screen has open, not a durable product master.

## API

- `products`: reactive `Map<productId, ResolvedProduct>`
- `resolve(ids)`: fetch any ids not already known or in flight; safe to call on every render
- `getByIds(ids)`: batched fetch without touching the shared map
- `reset()`: forget everything. Runs automatically on logout: `common/core/sessionScope.ts` is a small registry (`onSessionCleared` / `clearSessionScopedState`, both exported from the barrel) that `useAuth().logout()` sweeps right after the app's `postLogout` hook, and `useProducts` registers itself there, so no consumer has to wire it. A resolve that was in flight when the sweep ran is discarded (generation guard), so a logout mid-request cannot repopulate the map with the previous tenant's products.

## First consumer

hotwax/company: the Shopify inventory event page replaces its app-local `useProductNames` with this. That PR depends on this one merging first, because Company CI checks out accxui `main`.

## Verification

- `common/tests/useProducts.spec.ts`: 7 tests covering field mapping, dedupe of requested ids, Solr escaping and batching, error tolerance, `reset()`, a reset during an in-flight resolve, and the session-scope registration. `common/tests/sessionScope.spec.ts`: 2 tests for the registry.
- ESLint clean on the new files.
- `vue-tsc` from `apps/company` against this `common` reports no errors in the new module or the barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

