### PR TITLE
fix(common): restore the self-closing img tag in DxpShopifyImg

### DIFF
--- a/common/components/DxpShopifyImg.vue
+++ b/common/components/DxpShopifyImg.vue
@@ -1,5 +1,5 @@
 <template>
-  <img :src="imageUrl">
+  <img :src="imageUrl" />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## The problem

Every app's dev server is currently broken against `main`, rendering only a Vite error overlay:

```
[plugin:chrome-ide-trace-vue] Element is missing end tag.
common/components/DxpShopifyImg.vue
```

## Cause

#89 changed one character in the template:

```diff
-  <img :src="imageUrl" />
+  <img :src="imageUrl">
```

That is valid HTML, since `img` is a void element, and **production builds are unaffected** — which is why CI stayed green and this reached `main`. The `chrome-ide-trace-vue` plugin, which runs only in dev, parses each SFC to inject trace attributes and does not treat void elements as self-closing, so it throws and the module 500s.

## The fix

Restore the slash. #89's runtime change (preserving non-Shopify image URLs) is untouched; only the template line moves back.

## Verification

- Reproduced on a dev server against `main`: error overlay, module 500.
- With this change applied: the app loads and renders normally, no overlay.
- `pnpm build` passes both before and after, confirming the break was dev-only.
- Scanned every `.vue` under `common/` for bare void elements (`img`, `br`, `hr`, `input`, …): this was the only one, so nothing else trips it today.

## Follow-up worth filing separately

The plugin should treat HTML void elements as self-closing. Until it does, the next `<img>`, `<br>` or `<input>` written without a slash breaks local development for everyone, with a CI signal that stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)